### PR TITLE
Make JSONKeys and JSONValues node more lenient

### DIFF
--- a/src/nodes/data/json.tsx
+++ b/src/nodes/data/json.tsx
@@ -56,7 +56,7 @@ export class JSONKeys extends PureNode {
     inputObject: unknown,
     outputObject: Record<string, unknown>
   ): Promise<void> {
-    outputObject[outValueName] = Object.keys(inputObject[JSONName]);
+    outputObject[outValueName] = Object.keys(inputObject?.[JSONName]);
   }
 }
 
@@ -71,6 +71,6 @@ export class JSONValues extends PureNode {
     inputObject: unknown,
     outputObject: Record<string, unknown>
   ): Promise<void> {
-    outputObject[outValueName] = Object.values(inputObject[JSONName]);
+    outputObject[outValueName] = Object.values(inputObject?.[JSONName]);
   }
 }

--- a/src/nodes/data/json.tsx
+++ b/src/nodes/data/json.tsx
@@ -56,7 +56,7 @@ export class JSONKeys extends PureNode {
     inputObject: unknown,
     outputObject: Record<string, unknown>
   ): Promise<void> {
-    outputObject[outValueName] = Object.keys(inputObject?.[JSONName]);
+    outputObject[outValueName] = Object.keys(inputObject?.[JSONName] ?? {});
   }
 }
 
@@ -71,6 +71,6 @@ export class JSONValues extends PureNode {
     inputObject: unknown,
     outputObject: Record<string, unknown>
   ): Promise<void> {
-    outputObject[outValueName] = Object.values(inputObject?.[JSONName]);
+    outputObject[outValueName] = Object.values(inputObject?.[JSONName] ?? {});
   }
 }


### PR DESCRIPTION
When reloading the Get example the JSONKeys and JSONValues nodes kept throwing an error and the wiring would not show up. I think it was due to the array lookup getting an undefined or null value in some cases.