### PR TITLE
Node dragging performance improvement

### DIFF
--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -59,6 +59,7 @@ export default class PPGraph {
     | ((pos: PIXI.Point | null, data: unknown | null) => void)
     | null; // called when socket inspector should be opened
   onCloseSocketInspector: () => void; // called when socket inspector should be closed
+  onViewportDragging: ((isDraggingViewport: boolean) => void) | null; // called when the selection is being dragged
 
   onViewportMoveHandler: (event?: PIXI.InteractionEvent) => void;
 
@@ -139,6 +140,7 @@ export default class PPGraph {
     this._registeredNodeTypes = {};
 
     // define callbacks
+    this.onViewportDragging = (isDraggingViewport: boolean) => {};
   }
 
   // SETUP
@@ -179,6 +181,7 @@ export default class PPGraph {
     } else {
       this.viewport.cursor = 'grabbing';
       this.dragSourcePoint = new PIXI.Point(this.viewport.x, this.viewport.y);
+      this.onViewportDragging(true);
     }
   }
 
@@ -204,6 +207,7 @@ export default class PPGraph {
     this.viewport.cursor = 'grab';
     this.viewport.plugins.resume('drag');
     this.dragSourcePoint = null;
+    this.onViewportDragging(false);
   }
 
   _onNodePointerDown(event: PIXI.InteractionEvent): void {
@@ -349,6 +353,7 @@ export default class PPGraph {
     this._showComments = value;
     this.commentContainer.visible = value;
   }
+
   // METHODS
 
   clearTempConnection(): void {

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -59,7 +59,7 @@ export default class PPGraph {
     | ((pos: PIXI.Point | null, data: unknown | null) => void)
     | null; // called when socket inspector should be opened
   onCloseSocketInspector: () => void; // called when socket inspector should be closed
-  onViewportDragging: ((isDraggingViewport: boolean) => void) | null; // called when the selection is being dragged
+  onViewportDragging: ((isDraggingViewport: boolean) => void) | null; // called when the viewport is being dragged
 
   onViewportMoveHandler: (event?: PIXI.InteractionEvent) => void;
 

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -97,6 +97,7 @@ export default class PPNode extends PIXI.Container {
   onNodeAdded: (() => void) | null; // called when the node is added to the graph
   onNodeRemoved: (() => void) | null; // called when the node is removed from the graph
   onNodeSelected: (() => void) | null; // called when the node is selected/unselected
+  onNodeDragging: ((isDraggingNode: boolean) => void) | null; // called when the selection is being dragged
   onNodeResize: ((width: number, height: number) => void) | null; // called when the node is resized
   onNodeResized: (() => void) | null; // called when the node resize ended
   onNodeDragOrViewportMove: // called when the node or or the viewport with the node is moved or scaled
@@ -184,6 +185,9 @@ export default class PPNode extends PIXI.Container {
     this._doubleClicked = false;
 
     this._addListeners();
+
+    // define callbacks
+    this.onNodeDragging = (isDraggingNode: boolean) => {};
   }
 
   // GETTERS & SETTERS
@@ -316,6 +320,7 @@ export default class PPNode extends PIXI.Container {
 
   serialize(): SerializedNode {
     //create serialization object
+    // console.log(this);
     const node: SerializedNode = {
       id: this.id,
       name: this.name,
@@ -1053,6 +1058,7 @@ export default class PPNode extends PIXI.Container {
       this.cursor = 'grabbing';
       this.alpha = 0.5;
       this.isDraggingNode = true;
+      this.onNodeDragging(this.isDraggingNode);
       this.sourcePoint = this.interactionData.getLocalPosition(this);
 
       // subscribe to pointermove
@@ -1069,6 +1075,7 @@ export default class PPNode extends PIXI.Container {
 
     this.alpha = 1;
     this.isDraggingNode = false;
+    this.onNodeDragging(this.isDraggingNode);
     this.cursor = 'move';
     // set the interactionData to null
     this.interactionData = null;

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -320,7 +320,6 @@ export default class PPNode extends PIXI.Container {
 
   serialize(): SerializedNode {
     //create serialization object
-    console.log(this);
     const node: SerializedNode = {
       id: this.id,
       name: this.name,

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -97,7 +97,7 @@ export default class PPNode extends PIXI.Container {
   onNodeAdded: (() => void) | null; // called when the node is added to the graph
   onNodeRemoved: (() => void) | null; // called when the node is removed from the graph
   onNodeSelected: (() => void) | null; // called when the node is selected/unselected
-  onNodeDragging: ((isDraggingNode: boolean) => void) | null; // called when the selection is being dragged
+  onNodeDragging: ((isDraggingNode: boolean) => void) | null; // called when the node is being dragged
   onNodeResize: ((width: number, height: number) => void) | null; // called when the node is resized
   onNodeResized: (() => void) | null; // called when the node resize ended
   onNodeDragOrViewportMove: // called when the node or or the viewport with the node is moved or scaled
@@ -320,7 +320,7 @@ export default class PPNode extends PIXI.Container {
 
   serialize(): SerializedNode {
     //create serialization object
-    // console.log(this);
+    console.log(this);
     const node: SerializedNode = {
       id: this.id,
       name: this.name,

--- a/src/classes/SelectionClass.ts
+++ b/src/classes/SelectionClass.ts
@@ -30,6 +30,7 @@ export default class PPSelection extends PIXI.Container {
 
   protected onMoveHandler: (event?: PIXI.InteractionEvent) => void;
   onSelectionChange: ((selectedNodes: PPNode[]) => void) | null; // called when the selection has changed
+  onSelectionDragging: ((isDraggingSelection: boolean) => void) | null; // called when the selection is being dragged
   onSelectionRedrawn: ((screenPoint: PIXI.Point) => void) | null; // called when the selection is redrawn becaused its boundaries changed, were moved
 
   onRightClick:
@@ -76,8 +77,9 @@ export default class PPSelection extends PIXI.Container {
     this.onMoveHandler = this.onMove.bind(this);
 
     // define callbacks
-    this.onSelectionChange = (nodes: PPNode[]) => {}; //called if the selection changes
-    this.onSelectionRedrawn = () => {}; //called if the selection is moved
+    this.onSelectionChange = (nodes: PPNode[]) => {};
+    this.onSelectionDragging = (isDraggingSelection: boolean) => {};
+    this.onSelectionRedrawn = () => {};
   }
 
   get selectedNodes(): PPNode[] {
@@ -153,6 +155,7 @@ export default class PPSelection extends PIXI.Container {
         console.log('startDragAction');
         this.cursor = 'move';
         this.isDraggingSelection = true;
+        this.onSelectionDragging(this.isDraggingSelection);
         this.interactionData = event.data;
         this.sourcePoint = this.interactionData.getLocalPosition(
           this.selectedNodes[0]
@@ -177,6 +180,7 @@ export default class PPSelection extends PIXI.Container {
     if (this.isDraggingSelection) {
       this.cursor = 'default';
       this.isDraggingSelection = false;
+      this.onSelectionDragging(this.isDraggingSelection);
       this.interactionData = null;
       // unsubscribe from pointermove
       this.removeListener('pointermove', this.onMoveHandler);

--- a/src/components/GraphOverlay.tsx
+++ b/src/components/GraphOverlay.tsx
@@ -12,14 +12,23 @@ type GraphOverlayProps = {
 
 const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
   const [selectedNodes, setSelectedNodes] = useState<PPNode[]>([]);
+  const [isDraggingSelection, setIsDraggingSelection] = useState(false);
+  const [isDraggingNode, setIsDraggingNode] = useState(false);
 
   useEffect(() => {
     if (props.currentGraph) {
       // register callbacks when currentGraph mounted
       props.currentGraph.selection.onSelectionChange = setSelectedNodes;
+      props.currentGraph.selection.onSelectionDragging = setIsDraggingSelection;
     }
     console.log('GraphOverlay:', selectedNodes);
   }, [props.currentGraph]);
+
+  useEffect(() => {
+    if (selectedNodes.length === 1) {
+      selectedNodes[0].onNodeDragging = setIsDraggingNode;
+    }
+  }, [selectedNodes.length]);
 
   return (
     <>
@@ -32,6 +41,7 @@ const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
         selectedNodes={selectedNodes}
         currentGraph={props.currentGraph}
         randomMainColor={props.randomMainColor}
+        isDraggingSelection={isDraggingNode || isDraggingSelection}
       />
       <GraphOverlaySocketInspector
         currentGraph={props.currentGraph}

--- a/src/components/GraphOverlay.tsx
+++ b/src/components/GraphOverlay.tsx
@@ -42,9 +42,7 @@ const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
         selectedNodes={selectedNodes}
         currentGraph={props.currentGraph}
         randomMainColor={props.randomMainColor}
-        isDraggingSelection={
-          isDraggingViewport || isDraggingNode || isDraggingSelection
-        }
+        isDragging={isDraggingViewport || isDraggingNode || isDraggingSelection}
       />
       <GraphOverlaySocketInspector
         currentGraph={props.currentGraph}

--- a/src/components/GraphOverlay.tsx
+++ b/src/components/GraphOverlay.tsx
@@ -15,6 +15,7 @@ const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
   const [isDraggingSelection, setIsDraggingSelection] = useState(false);
   const [isDraggingNode, setIsDraggingNode] = useState(false);
   const [isDraggingViewport, setIsDraggingViewport] = useState(false);
+  const [isZoomingViewport, setIsZoomingViewport] = useState(false);
 
   useEffect(() => {
     if (props.currentGraph) {
@@ -22,6 +23,12 @@ const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
       props.currentGraph.selection.onSelectionChange = setSelectedNodes;
       props.currentGraph.selection.onSelectionDragging = setIsDraggingSelection;
       props.currentGraph.onViewportDragging = setIsDraggingViewport;
+      props.currentGraph.viewport.on('zoomed', () => {
+        setIsZoomingViewport(true);
+      });
+      props.currentGraph.viewport.on('zoomed-end', () => {
+        setIsZoomingViewport(false);
+      });
     }
   }, [props.currentGraph]);
 
@@ -42,7 +49,12 @@ const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
         selectedNodes={selectedNodes}
         currentGraph={props.currentGraph}
         randomMainColor={props.randomMainColor}
-        isDragging={isDraggingViewport || isDraggingNode || isDraggingSelection}
+        isDragging={
+          isZoomingViewport ||
+          isDraggingViewport ||
+          isDraggingNode ||
+          isDraggingSelection
+        }
       />
       <GraphOverlaySocketInspector
         currentGraph={props.currentGraph}

--- a/src/components/GraphOverlay.tsx
+++ b/src/components/GraphOverlay.tsx
@@ -14,21 +14,22 @@ const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
   const [selectedNodes, setSelectedNodes] = useState<PPNode[]>([]);
   const [isDraggingSelection, setIsDraggingSelection] = useState(false);
   const [isDraggingNode, setIsDraggingNode] = useState(false);
+  const [isDraggingViewport, setIsDraggingViewport] = useState(false);
 
   useEffect(() => {
     if (props.currentGraph) {
       // register callbacks when currentGraph mounted
       props.currentGraph.selection.onSelectionChange = setSelectedNodes;
       props.currentGraph.selection.onSelectionDragging = setIsDraggingSelection;
+      props.currentGraph.onViewportDragging = setIsDraggingViewport;
     }
-    console.log('GraphOverlay:', selectedNodes);
   }, [props.currentGraph]);
 
   useEffect(() => {
     if (selectedNodes.length === 1) {
       selectedNodes[0].onNodeDragging = setIsDraggingNode;
     }
-  }, [selectedNodes.length]);
+  }, [selectedNodes]);
 
   return (
     <>
@@ -41,7 +42,9 @@ const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
         selectedNodes={selectedNodes}
         currentGraph={props.currentGraph}
         randomMainColor={props.randomMainColor}
-        isDraggingSelection={isDraggingNode || isDraggingSelection}
+        isDraggingSelection={
+          isDraggingViewport || isDraggingNode || isDraggingSelection
+        }
       />
       <GraphOverlaySocketInspector
         currentGraph={props.currentGraph}

--- a/src/components/GraphOverlayNodeMenu.tsx
+++ b/src/components/GraphOverlayNodeMenu.tsx
@@ -9,6 +9,7 @@ type GraphOverlayNodeMenuProps = {
   currentGraph: PPGraph;
   randomMainColor: string;
   selectedNodes: PPNode[];
+  isDraggingSelection: boolean;
 };
 
 const GraphOverlayNodeMenu: React.FunctionComponent<
@@ -31,16 +32,18 @@ const GraphOverlayNodeMenu: React.FunctionComponent<
 
   return (
     <Box sx={{ position: 'relative' }}>
-      {props.selectedNodes.length > 0 && selectionPos && (
-        <FloatingNodeMenu
-          x={
-            selectionPos.x +
-            props.currentGraph.selection.selectionGraphics.width / 2
-          }
-          y={Math.max(0, selectionPos.y - 40)}
-          selectedNodes={props.selectedNodes}
-        />
-      )}
+      {props.selectedNodes.length > 0 &&
+        selectionPos &&
+        !props.isDraggingSelection && (
+          <FloatingNodeMenu
+            x={
+              selectionPos.x +
+              props.currentGraph.selection.selectionGraphics.width / 2
+            }
+            y={Math.max(0, selectionPos.y - 40)}
+            selectedNodes={props.selectedNodes}
+          />
+        )}
     </Box>
   );
 };

--- a/src/components/GraphOverlayNodeMenu.tsx
+++ b/src/components/GraphOverlayNodeMenu.tsx
@@ -9,7 +9,7 @@ type GraphOverlayNodeMenuProps = {
   currentGraph: PPGraph;
   randomMainColor: string;
   selectedNodes: PPNode[];
-  isDraggingSelection: boolean;
+  isDragging: boolean;
 };
 
 const GraphOverlayNodeMenu: React.FunctionComponent<
@@ -32,18 +32,16 @@ const GraphOverlayNodeMenu: React.FunctionComponent<
 
   return (
     <Box sx={{ position: 'relative' }}>
-      {props.selectedNodes.length > 0 &&
-        selectionPos &&
-        !props.isDraggingSelection && (
-          <FloatingNodeMenu
-            x={
-              selectionPos.x +
-              props.currentGraph.selection.selectionGraphics.width / 2
-            }
-            y={Math.max(0, selectionPos.y - 40)}
-            selectedNodes={props.selectedNodes}
-          />
-        )}
+      {props.selectedNodes.length > 0 && selectionPos && !props.isDragging && (
+        <FloatingNodeMenu
+          x={
+            selectionPos.x +
+            props.currentGraph.selection.selectionGraphics.width / 2
+          }
+          y={Math.max(0, selectionPos.y - 40)}
+          selectedNodes={props.selectedNodes}
+        />
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
I suggest to hide the node menu overlay during these actions. 
* the node was dragged
* the selection was dragged (multiple nodes)
* the viewport was dragged or zoomed

I found out that the node menu re-rendered on all these actions. This was particularly heavy as the menu had included a serialize node method in there. Maybe that could also be improved, but hiding it helps already a lot. Please have a look

<img width="266" alt="Screen Shot 2022-02-15 at 20 58 46" src="https://user-images.githubusercontent.com/4619772/154141107-618fecbd-19ce-48fb-ac14-52339883a56b.png">

