### PR TITLE
Store viewport position

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,6 +102,7 @@ const App = (): JSX.Element => {
   const mousePosition = { x: 0, y: 0 };
   const pixiDebugRef = new PIXI.Text('', COMMENT_TEXTSTYLE);
   pixiDebugRef.resolution = 1;
+  pixiDebugRef.x = 4;
 
   const db = new GraphDatabase();
   const pixiApp = useRef<PIXI.Application | null>(null);
@@ -147,10 +148,12 @@ const App = (): JSX.Element => {
     const viewportScreenX = Math.round(viewport.current.x);
     const viewportScreenY = Math.round(viewport.current.y);
     const viewportScale = roundNumber(viewport.current.scale.x);
-    pixiDebugRef.text = `mouse: ${mousePosition.x}, ${
+    pixiDebugRef.text = `Mouse position (world): ${mousePosition.x}, ${
       mousePosition.y
     } (${mouseWorldX}, ${mouseWorldY})
-viewport: ${viewportScreenX}, ${Math.round(viewportScreenY)}, ${viewportScale}`;
+Viewport position (scale): ${viewportScreenX}, ${Math.round(
+      viewportScreenY
+    )} (${viewportScale})`;
   };
 
   // react-dropzone

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,9 +44,12 @@ import { GraphContextMenu, NodeContextMenu } from './components/ContextMenus';
 import { GraphDatabase } from './utils/indexedDB';
 import PPGraph from './classes/GraphClass';
 import {
+  BASIC_VERTEX_SHADER,
   CANVAS_BACKGROUND_ALPHA,
   CANVAS_BACKGROUND_TEXTURE,
+  COMMENT_TEXTSTYLE,
   DRAGANDDROP_GRID_MARGIN,
+  GRID_SHADER,
   NODE_WIDTH,
   PLUGANDPLAY_ICON,
   RANDOMMAINCOLOR,
@@ -63,6 +66,7 @@ import {
   getSelectionBounds,
   isEventComingFromWithinTextInput,
   removeExtension,
+  roundNumber,
   useStateRef,
 } from './utils/utils';
 import { registerAllNodeTypes } from './nodes/allNodes';
@@ -96,12 +100,15 @@ const App = (): JSX.Element => {
   const githubBranchName = 'dev';
 
   const mousePosition = { x: 0, y: 0 };
+  const pixiDebugRef = new PIXI.Text('', COMMENT_TEXTSTYLE);
+  pixiDebugRef.resolution = 1;
 
   const db = new GraphDatabase();
   const pixiApp = useRef<PIXI.Application | null>(null);
   const currentGraph = useRef<PPGraph | null>(null);
   const pixiContext = useRef<HTMLDivElement | null>(null);
   const viewport = useRef<Viewport | null>(null);
+  const overlayCommentContainer = useRef<PIXI.Container | null>(null);
   const graphSearchInput = useRef<HTMLInputElement | null>(null);
   const nodeSearchInput = useRef<HTMLInputElement | null>(null);
   const [isGraphSearchOpen, setIsGraphSearchOpen] = useState(false);
@@ -129,6 +136,22 @@ const App = (): JSX.Element => {
   const [showDeleteGraph, setShowDeleteGraph] = useState(false);
 
   let lastTimeTicked = 0;
+
+  // get/set mouse position and also update debug text
+  const setMousePosition = (mouseMoveEvent) => {
+    mousePosition.x = mouseMoveEvent.pageX;
+    mousePosition.y = mouseMoveEvent.pageY;
+    const mouseWorld = viewport.current.toWorld(mousePosition);
+    const mouseWorldX = Math.round(mouseWorld.x);
+    const mouseWorldY = Math.round(mouseWorld.y);
+    const viewportScreenX = Math.round(viewport.current.x);
+    const viewportScreenY = Math.round(viewport.current.y);
+    const viewportScale = roundNumber(viewport.current.scale.x);
+    pixiDebugRef.text = `mouse: ${mousePosition.x}, ${
+      mousePosition.y
+    } (${mouseWorldX}, ${mouseWorldY})
+viewport: ${viewportScreenX}, ${Math.round(viewportScreenY)}, ${viewportScale}`;
+  };
 
   // react-dropzone
   const onDrop = useCallback((acceptedFiles, fileRejections, event) => {
@@ -297,14 +320,7 @@ const App = (): JSX.Element => {
       { passive: false }
     );
 
-    window.addEventListener(
-      'mousemove',
-      function (mouseMoveEvent) {
-        mousePosition.x = mouseMoveEvent.pageX;
-        mousePosition.y = mouseMoveEvent.pageY;
-      },
-      false
-    );
+    window.addEventListener('mousemove', setMousePosition, false);
 
     // create viewport
     viewport.current = new Viewport({
@@ -331,6 +347,13 @@ const App = (): JSX.Element => {
         maxScale: 4,
       });
 
+    // add overlayCommentContainer to the stage
+    overlayCommentContainer.current = new PIXI.Container();
+    overlayCommentContainer.current.name = 'OverlayContainer';
+
+    pixiApp.current.stage.addChild(overlayCommentContainer.current);
+    overlayCommentContainer.current.addChild(pixiDebugRef);
+
     // add pixiApp to canvas
     pixiContext.current.appendChild(pixiApp.current.view);
 
@@ -344,7 +367,7 @@ const App = (): JSX.Element => {
     background.tileScale.x = 0.5;
     background.tileScale.y = 0.5;
     viewport.current.addChild(background);
-    viewport.current.on('moved', () => {
+    viewport.current.on('moved', (event) => {
       background.tilePosition.y = -viewport.current.top;
       background.tilePosition.x = -viewport.current.left;
       background.y = viewport.current.top;
@@ -352,9 +375,30 @@ const App = (): JSX.Element => {
 
       background.width = innerWidth / viewport.current.scale.x;
       background.height = innerHeight / viewport.current.scale.y;
+
+      setMousePosition(event);
     });
 
     background.alpha = CANVAS_BACKGROUND_ALPHA;
+
+    const geometry = new PIXI.Geometry()
+      .addAttribute('aVertexPosition', [0, 0, 1000, 0, 1000, 1000, 0, 1000], 2)
+      .addAttribute('aUvs', [0, 0, 1, 0, 1, 1, 0, 1], 2)
+      .addIndex([0, 1, 2, 0, 2, 3]);
+
+    const gridUniforms = {
+      x: 0,
+      y: 0,
+      zoom: 5,
+    };
+    const gridShader = PIXI.Shader.from(
+      BASIC_VERTEX_SHADER,
+      GRID_SHADER,
+      gridUniforms
+    );
+    const gridQuad = new PIXI.Mesh(geometry, gridShader);
+    gridQuad.name = 'debugGrid';
+    viewport.current.addChild(gridQuad);
 
     // add graph to pixiApp
     currentGraph.current = new PPGraph(pixiApp.current, viewport.current);
@@ -445,6 +489,12 @@ const App = (): JSX.Element => {
       // console.log(e.key);
       if (e.shiftKey) {
         viewport.current.cursor = 'default';
+      }
+      if ((isMac ? e.metaKey : e.ctrlKey) && e.key === 'u') {
+        // added ctrl+u shortcut for trying to debug the issue where drag would stop working
+        // I want to see if the plugin was just paused
+        console.log(viewport);
+        viewport.current.plugins.resume('drag');
       }
       if (!isEventComingFromWithinTextInput(e)) {
         if ((isMac ? e.metaKey : e.ctrlKey) && e.key === 'a') {
@@ -556,6 +606,9 @@ const App = (): JSX.Element => {
 
   useEffect(() => {
     currentGraph.current.showComments = showComments;
+    overlayCommentContainer.current.visible = showComments;
+    (viewport.current.getChildByName('debugGrid') as PIXI.Mesh).visible =
+      showComments;
   }, [showComments]);
 
   const moveToCenter = (bounds: PIXI.Rectangle) => {

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -684,10 +684,14 @@ export default class PPGraph {
     );
 
     const data = {
-      customNodeTypes: this.customNodeTypes,
+      version: PP_VERSION,
+      graphSettings: {
+        viewportCenterPosition: this.viewport.center,
+        viewportScale: this.viewport.scale.x,
+      },
       nodes: nodesSerialized,
       links: linksSerialized,
-      version: PP_VERSION,
+      customNodeTypes: this.customNodeTypes,
     };
 
     return data;
@@ -714,6 +718,16 @@ export default class PPGraph {
 
     // store customNodeTypes
     this.customNodeTypes = data.customNodeTypes;
+
+    // position and scale viewport
+    const newX = data.graphSettings?.viewportCenterPosition.x ?? 0;
+    const newY = data.graphSettings?.viewportCenterPosition.y ?? 0;
+    this.viewport.animate({
+      position: new PIXI.Point(newX, newY),
+      scale: data.graphSettings?.viewportScale ?? 1,
+      ease: 'easeOutExpo',
+      time: 750,
+    });
 
     //create nodes
     const nodes = data.nodes;

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -720,11 +720,11 @@ export default class PPGraph {
     this.customNodeTypes = data.customNodeTypes;
 
     // position and scale viewport
-    const newX = data.graphSettings?.viewportCenterPosition.x ?? 0;
-    const newY = data.graphSettings?.viewportCenterPosition.y ?? 0;
+    const newX = data.graphSettings.viewportCenterPosition.x ?? 0;
+    const newY = data.graphSettings.viewportCenterPosition.y ?? 0;
     this.viewport.animate({
       position: new PIXI.Point(newX, newY),
-      scale: data.graphSettings?.viewportScale ?? 1,
+      scale: data.graphSettings.viewportScale ?? 1,
       ease: 'easeOutExpo',
       time: 750,
     });

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -259,3 +259,40 @@ export const OBJECT_FIT_OPTIONS: EnumStructure = [
     text: 'scale-down',
   },
 ];
+
+export const GRID_SHADER = `
+  precision mediump float;
+  varying vec2 vUvs;
+  uniform float zoom;
+
+  void main()
+  {
+      //Generate a simple grid.
+      //Offset uv so that center is 0,0 and edges are -1,1
+      vec2 uv = (vUvs-vec2(0.5))*2.0;
+      vec2 gUv = floor(uv*zoom);
+      vec4 color1 = vec4(0.0, 0.0, 0.0, 0.0);
+      vec4 color2 = vec4(0.0, 0.0, 0.0, 0.05);
+      vec4 outColor = mod(gUv.x + gUv.y, 2.) < 0.5 ? color1 : color2;
+      gl_FragColor = outColor;
+
+  }`;
+
+// Vertex shader. Use same shader for all passes.
+export const BASIC_VERTEX_SHADER = `
+  precision mediump float;
+
+  attribute vec2 aVertexPosition;
+  attribute vec2 aUvs;
+
+  uniform mat3 translationMatrix;
+  uniform mat3 projectionMatrix;
+
+  varying vec2 vUvs;
+
+  void main() {
+
+      vUvs = aUvs;
+      gl_Position = vec4((projectionMatrix * translationMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
+
+  }`;

--- a/src/utils/interfaces.tsx
+++ b/src/utils/interfaces.tsx
@@ -1,3 +1,4 @@
+import * as PIXI from 'pixi.js';
 import PPGraph from '../classes/GraphClass';
 import PPNode, { UpdateBehaviour } from '../classes/NodeClass';
 import { AbstractType } from '../nodes/datatypes/abstractType';
@@ -21,6 +22,10 @@ export type PPNodeConstructor<T extends PPNode = PPNode> = {
 
 export type SerializedGraph = {
   version: number;
+  graphSettings: {
+    viewportCenterPosition: PIXI.Point;
+    viewportScale: number;
+  };
   nodes: SerializedNode[];
   links: SerializedLink[];
   customNodeTypes: Record<string, string>;


### PR DESCRIPTION
Added saving and loading of viewport position and scale. So after loading you see the exact same section of the graph you had when saving.
For this I have also added a bit more debugging info. Mouse and viewport coordinates on the top left and a grid shader texture spanning from 0,0 - 1000,1000.

<img width="769" alt="Screenshot 2022-02-20 at 17 05 54" src="https://user-images.githubusercontent.com/4619772/154852217-c8ac3a62-68d6-41ed-b300-bef435f78f88.png">
