### PR TITLE
Improve pan zoom handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -347,9 +347,13 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
 
     // configure viewport
     viewport.current
-      .drag()
+      .drag({
+        clampWheel: false,
+        // keyToPress: ['Space'],
+        mouseButtons: 'middle',
+      })
       .pinch()
-      .wheel()
+      .wheel({ smooth: 3, trackpadPinch: true, wheelZoom: false })
       .decelerate({
         friction: 0.8,
       })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -349,8 +349,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     viewport.current
       .drag({
         clampWheel: false,
-        // keyToPress: ['Space'],
-        mouseButtons: 'middle',
+        mouseButtons: 'middle-right',
       })
       .pinch()
       .wheel({ smooth: 3, trackpadPinch: true, wheelZoom: false })
@@ -502,9 +501,6 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     // register key events
     const keysDown = (e: KeyboardEvent): void => {
       // console.log(e.key);
-      if (e.shiftKey) {
-        viewport.current.cursor = 'default';
-      }
       if ((isMac ? e.metaKey : e.ctrlKey) && e.key === 'u') {
         // added ctrl+u shortcut for trying to debug the issue where drag would stop working
         // I want to see if the plugin was just paused
@@ -564,9 +560,9 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
       InputParser.parseKeyDown(e, currentGraph.current)
     );
 
-    window.addEventListener('keyup', (e: KeyboardEvent) =>
-      InputParser.parseKeyUp(e)
-    );
+    window.addEventListener('keyup', (e: KeyboardEvent) => {
+      InputParser.parseKeyUp(e);
+    });
 
     return () => {
       // Passing the same reference

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -314,10 +314,14 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     pixiApp.current.stage.buttonMode = true;
 
     // disable browser window zoom on trackpad pinch
-    pixiApp.current.view.addEventListener(
-      'mousewheel',
-      (e: Event) => {
-        e.preventDefault();
+    document.addEventListener(
+      'wheel',
+      (event) => {
+        const { ctrlKey } = event;
+        if (ctrlKey) {
+          event.preventDefault();
+          return;
+        }
       },
       { passive: false }
     );

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -36,7 +36,7 @@ export default class PPGraph {
   selectedSourceSocket: null | Socket;
   lastSelectedSocketWasInput = false;
   overInputRef: null | Socket;
-  dragSourcePoint: null | PIXI.Point;
+  dragSourcePoint: PIXI.Point;
 
   backgroundTempContainer: PIXI.Container;
   backgroundCanvas: PIXI.Container;
@@ -143,7 +143,7 @@ export default class PPGraph {
     console.log(target, event.data.originalEvent);
     if (
       // only trigger right click if viewport was not dragged
-      this.dragSourcePoint === null ||
+      this.dragSourcePoint === undefined ||
       (this.dragSourcePoint.x === this.viewport.x &&
         this.dragSourcePoint.y === this.viewport.y)
     ) {
@@ -192,7 +192,7 @@ export default class PPGraph {
     console.log('_onPointerUpAndUpOutside');
     // check if viewport has been dragged,
     // if not, this is a deselect all nodes action
-    if (this.dragSourcePoint !== null) {
+    if (this.dragSourcePoint !== undefined) {
       if (
         this.dragSourcePoint.x === this.viewport.x &&
         this.dragSourcePoint.y === this.viewport.y
@@ -209,7 +209,7 @@ export default class PPGraph {
 
     this.viewport.cursor = 'default';
     this.viewport.plugins.resume('drag');
-    this.dragSourcePoint = null;
+    this.dragSourcePoint = undefined;
     this.onViewportDragging(false);
   }
 
@@ -351,7 +351,7 @@ export default class PPGraph {
 
   clearTempConnection(): void {
     this.tempConnection.clear();
-    this.dragSourcePoint = null;
+    this.dragSourcePoint = undefined;
   }
 
   getNodeById(id: string): PPNode {

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -105,7 +105,7 @@ export default class PPGraph {
     );
     this.app.stage.addChild(this.selection);
 
-    this.viewport.cursor = 'grab';
+    this.viewport.cursor = 'default';
 
     // add event listeners
     // listen to window resize event and resize app
@@ -141,8 +141,14 @@ export default class PPGraph {
     event.stopPropagation();
     const target = event.target;
     console.log(target, event.data.originalEvent);
-
-    this.onRightClick(event, target);
+    if (
+      // only trigger right click if viewport was not dragged
+      this.dragSourcePoint === null ||
+      (this.dragSourcePoint.x === this.viewport.x &&
+        this.dragSourcePoint.y === this.viewport.y)
+    ) {
+      this.onRightClick(event, target);
+    }
   }
 
   _onPointerDoubleClicked(event: PIXI.InteractionEvent): void {
@@ -160,7 +166,7 @@ export default class PPGraph {
 
     this.onCloseSocketInspector();
 
-    if (event.data.originalEvent.shiftKey) {
+    if ((event.data.originalEvent as PointerEvent).button === 0) {
       this.selection.drawSelectionStart(
         event,
         event.data.originalEvent.shiftKey
@@ -198,10 +204,10 @@ export default class PPGraph {
       }
     }
     if (this.selection.isDrawingSelection) {
-      this.selection.drawSelectionFinish();
+      this.selection.drawSelectionFinish(event);
     }
 
-    this.viewport.cursor = 'grab';
+    this.viewport.cursor = 'default';
     this.viewport.plugins.resume('drag');
     this.dragSourcePoint = null;
     this.onViewportDragging(false);

--- a/src/classes/SelectionClass.ts
+++ b/src/classes/SelectionClass.ts
@@ -287,7 +287,7 @@ export default class PPSelection extends PIXI.Container {
     this.on('pointermove', this.onMoveHandler);
   }
 
-  drawSelectionFinish(): void {
+  drawSelectionFinish(event: PIXI.InteractionEvent): void {
     this.isDrawingSelection = false;
     this.selectionIntendGraphics.clear();
 
@@ -303,6 +303,21 @@ export default class PPSelection extends PIXI.Container {
       this.resetAllGraphics();
     }
     this.onSelectionChange(this.selectedNodes);
+
+    // only trigger deselect if the mouse was not moved and onMove was not called
+    const targetPoint = new PIXI.Point(
+      (event.data.originalEvent as MouseEvent).clientX,
+      (event.data.originalEvent as MouseEvent).clientY
+    );
+    if (this.sourcePoint !== null) {
+      if (
+        this.sourcePoint.x === targetPoint.x &&
+        this.sourcePoint.y === targetPoint.y
+      ) {
+        console.log('deselectAllNodesAndResetSelection');
+        this.deselectAllNodesAndResetSelection();
+      }
+    }
   }
 
   drawSingleSelections(): void {

--- a/src/classes/SelectionClass.ts
+++ b/src/classes/SelectionClass.ts
@@ -23,7 +23,7 @@ export default class PPSelection extends PIXI.Container {
   protected singleSelectionsGraphics: PIXI.Graphics;
   protected scaleHandle: ScaleHandle;
 
-  protected sourcePoint: null | PIXI.Point;
+  protected sourcePoint: PIXI.Point;
   isDrawingSelection: boolean;
   isDraggingSelection: boolean;
   interactionData: PIXI.InteractionData | null;
@@ -41,7 +41,7 @@ export default class PPSelection extends PIXI.Container {
     super();
     this.viewport = viewport;
     this.getNodes = getNodes;
-    this.sourcePoint = null;
+    this.sourcePoint = new PIXI.Point(0, 0);
     this.isDrawingSelection = false;
     this.isDraggingSelection = false;
     this.previousSelectedNodes = [];
@@ -309,14 +309,12 @@ export default class PPSelection extends PIXI.Container {
       (event.data.originalEvent as MouseEvent).clientX,
       (event.data.originalEvent as MouseEvent).clientY
     );
-    if (this.sourcePoint !== null) {
-      if (
-        this.sourcePoint.x === targetPoint.x &&
-        this.sourcePoint.y === targetPoint.y
-      ) {
-        console.log('deselectAllNodesAndResetSelection');
-        this.deselectAllNodesAndResetSelection();
-      }
+    if (
+      this.sourcePoint.x === targetPoint.x &&
+      this.sourcePoint.y === targetPoint.y
+    ) {
+      console.log('deselectAllNodesAndResetSelection');
+      this.deselectAllNodesAndResetSelection();
     }
   }
 


### PR DESCRIPTION
Something different I worked on the weekend. I tried to make the pan and zoom handling more similar to Miro/Blueprints and it seems to work well for me. I tested it on a Mac and a Pc with trackpad and mouse. It might need some more testing on different devices. This is the new behaviour:
* Drag with trackpad or middle or right mouse click
* Zoom with trackpad using pinch or ctrl scroll
* Zoom with mouse using scrollwheel
* Select with left click (shift key is only need for adding or subtracting the selection)