### PR TITLE
Fixing copy paste

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -336,6 +336,40 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
       { passive: false }
     );
 
+    document.addEventListener('copy', async (e) => {
+      console.dir(e.target);
+      e.preventDefault();
+      // e.stopPropagation();
+      if (!isEventComingFromWithinTextInput(e)) {
+        const serializeSelection = currentGraph.current.serializeSelection();
+        writeDataToClipboard(serializeSelection);
+        console.log(serializeSelection);
+      }
+    });
+
+    document.addEventListener('paste', async (e) => {
+      console.dir(e.target);
+      if (!isEventComingFromWithinTextInput(e)) {
+        e.preventDefault();
+        // e.stopPropagation();
+        const textFromClipboard = await navigator.clipboard.readText();
+        try {
+          const json = JSON.parse(textFromClipboard) as SerializedSelection;
+          if (json.version) {
+            const pastedNodes = await currentGraph.current.pasteNodes(
+              json,
+              true
+            );
+            console.log(pastedNodes);
+          } else {
+            console.error('Not valid');
+          }
+        } catch (e) {
+          console.error('There was an issue pasting');
+        }
+      }
+    });
+
     window.addEventListener('mousemove', setMousePosition, false);
 
     // create viewport
@@ -568,36 +602,6 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     window.addEventListener('keyup', (e: KeyboardEvent) =>
       InputParser.parseKeyUp(e)
     );
-
-    window.addEventListener('copy', async (e) => {
-      if (!isEventComingFromWithinTextInput(e)) {
-        e.preventDefault();
-        const serializeSelection = currentGraph.current.serializeSelection();
-        writeDataToClipboard(serializeSelection);
-        console.log(serializeSelection);
-      }
-    });
-
-    window.addEventListener('paste', async (e) => {
-      if (!isEventComingFromWithinTextInput(e)) {
-        e.preventDefault();
-        const textFromClipboard = await navigator.clipboard.readText();
-        try {
-          const json = JSON.parse(textFromClipboard) as SerializedSelection;
-          if (json.version) {
-            const pastedNodes = await currentGraph.current.pasteNodes(
-              json,
-              true
-            );
-            console.log(pastedNodes);
-          } else {
-            console.error('Not valid');
-          }
-        } catch (e) {
-          console.error('There was an issue pasting');
-        }
-      }
-    });
 
     return () => {
       // Passing the same reference

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -357,6 +357,7 @@ export const isEventComingFromWithinTextInput = (event: any): boolean => {
     event.target.id === 'Input' ||
     event.target.localName === 'input' ||
     event.target.localName === 'textarea' ||
+    event.target.className.includes('ͼw') ||
     event.target.className.includes('cm-content') ||
     event.target.className.includes('cm-scroller')
   );

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -357,7 +357,6 @@ export const isEventComingFromWithinTextInput = (event: any): boolean => {
     event.target.id === 'Input' ||
     event.target.localName === 'input' ||
     event.target.localName === 'textarea' ||
-    event.target.className.includes('ͼw') ||
     event.target.className.includes('cm-content') ||
     event.target.className.includes('cm-scroller')
   );


### PR DESCRIPTION
I have changed 
* the copy event
  * if text selection is empty when the copy event occurs we prevent the default action and copy selected nodes into the clipboard
* the paste event
  * we get the text from the clipboard and try to parse it, if it is parseable we prevent the default and create nodes, if not we let it pass and let the default paste action go through
