### PR TITLE
Fixing issue messing with table data when editing

### DIFF
--- a/src/utils/xlsxspread.ts
+++ b/src/utils/xlsxspread.ts
@@ -94,13 +94,13 @@ export function xtos(sdata: any): XLSX.WorkBook {
           if (idx > maxCoord.c) maxCoord.c = idx;
         }
 
-        let cellText = row.cells[k].text,
-          type = 's';
+        let cellText = row.cells[k].text;
+        let type = 's';
         if (!cellText) {
           cellText = '';
           type = 'z';
-        } else if (!isNaN(parseFloat(cellText))) {
-          cellText = parseFloat(cellText);
+        } else if (!isNaN(Number(cellText))) {
+          cellText = Number(cellText);
           type = 'n';
         } else if (
           cellText.toLowerCase() === 'true' ||


### PR DESCRIPTION
The included script transforming the data between x-spreadsheet and sheetjs had a very lax threshold for detecting/formatting string data to numbers. I have now added a stricter number conversion of cell data.