### PR TITLE
Fix react crash due to inspector

### DIFF
--- a/src/components/FloatingSocketInspector.tsx
+++ b/src/components/FloatingSocketInspector.tsx
@@ -28,7 +28,7 @@ function PaperComponent(props) {
     <Draggable
       handle="#draggable-title"
       cancel={'[id=draggable-content]'}
-      key={`${props.socketinfo?.parent.id}.${props.socketinfo?.name}`}
+      key={`${props.socketinfo.parent.id}.${props.socketinfo.name}`}
     >
       <Paper {...props} />
     </Draggable>

--- a/src/components/GraphOverlaySocketInspector.tsx
+++ b/src/components/GraphOverlaySocketInspector.tsx
@@ -48,7 +48,7 @@ const GraphOverlaySocketInspector: React.FunctionComponent<
 
   return (
     <Box sx={{ position: 'relative' }}>
-      {socketToInspect && (
+      {socketToInspect && socketToInspect.parent && (
         <FloatingSocketInspector
           socketInspectorPosition={socketInspectorPosition}
           socketToInspect={socketToInspect}


### PR DESCRIPTION
This fixes a crash of react when the floating inspector is open and its node gets deleted.