### PR TITLE
Fixing insert and socket clicking bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -525,7 +525,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
           break;
         case target instanceof Viewport:
           console.log('app right click, viewport');
-          setContextMenuPosition([contextMenuPosX, contextMenuPosY(80)]);
+          setContextMenuPosition([contextMenuPosX, contextMenuPosY(600)]);
           setIsGraphContextMenuOpen(true);
           break;
         default:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -946,10 +946,11 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
   const handleNodeItemSelect = (event, selected: INodeSearch) => {
     console.log(selected);
     // store link before search gets hidden and temp connection gets reset
-    const pos =
+    const nodePos =
       currentGraph.current.overrideNodeCursorPosition ??
-      new PIXI.Point(contextMenuPosition[0], contextMenuPosition[1]);
-    const nodePos = viewport.current.toWorld(pos.x, pos.y);
+      viewport.current.toWorld(
+        new PIXI.Point(contextMenuPosition[0], contextMenuPosition[1])
+      );
     const addLink = currentGraph.current.selectedSourceSocket;
 
     const nodeExists = getAllNodeTypes()[selected.title] !== undefined;

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -158,10 +158,12 @@ export default class PPGraph {
     this.onCloseSocketInspector();
 
     if ((event.data.originalEvent as PointerEvent).button === 0) {
-      this.selection.drawSelectionStart(
-        event,
-        event.data.originalEvent.shiftKey
-      );
+      if (!this.overInputRef) {
+        this.selection.drawSelectionStart(
+          event,
+          event.data.originalEvent.shiftKey
+        );
+      }
 
       // pause viewport drag
       this.viewport.plugins.pause('drag');


### PR DESCRIPTION
This fixes
* a bug where the node was not inserted at the correct place. I had doubled up the toWorld calculation.
* a bug where a selection rectangle was drawn when trying to unplug/replug a socket
* a bug where the viewport context menu would be cut off when right clicked too low on the screen

https://user-images.githubusercontent.com/4619772/176955279-a9c56f87-a345-4c4f-aed1-ef1067f40484.mp4
