### PR TITLE
Fix losing defaultData

### DIFF
--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -381,7 +381,7 @@ export default class PPNode extends PIXI.Container {
         if (matchingSocket !== undefined) {
           matchingSocket.dataType = deSerializeType(item.dataType);
           matchingSocket.data = item.data;
-          matchingSocket.defaultData = item.defaultData;
+          matchingSocket.defaultData = item.defaultData ?? item.data;
           matchingSocket.setVisible(item.visible);
         } else {
           // add socket if it does not exist yet


### PR DESCRIPTION
The original socket value is lost after
* linking a value
* saving the graph
* reloading the graph
* then unlinking it