### PR TITLE
Load graph via url

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -321,6 +321,9 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
   useEffect(() => {
     console.log(pixiContext.current);
 
+    const urlParams = new URLSearchParams(window.location.search);
+    console.log(urlParams.getAll('url'));
+
     // create pixiApp
     pixiApp.current = new PIXI.Application({
       backgroundColor: randomMainColorLightHex,


### PR DESCRIPTION
Added an option to load a graph from a link included in the URL.

How to:
1. Upload your graph to e.g. github
2. Get the "raw" URL to the file
3. Add the URL as the value of the URL parameter `loadURL`

Example:
`http://localhost:8080/?loadURL=https://raw.githubusercontent.com/fakob/plug-and-play-examples/dev/Get%20API%20example.ppgraph`

NOTE:
We have a dedicated [repo for graphs](https://github.com/fakob/plug-and-play-examples) where you could upload yours. The dev branch is grabbed and shown in the graph dropdown. If you do not want it to show up there, just create a new branch.