### PR TITLE
Fix code editor height

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -34,7 +34,7 @@ export const CodeEditor: React.FunctionComponent<CodeEditorProps> = (props) => {
   };
 
   const editorDidMount = (editor) => {
-    console.log('editorDidMount', editor);
+    // console.log('editorDidMount', editor);
     editorRef.current = editor;
     changeEditorHeight();
     editorRef.current.focus();

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import MonacoEditor from 'react-monaco-editor';
+import MonacoEditor, { monaco } from 'react-monaco-editor';
 import { Box, Button } from '@mui/material';
 import ErrorFallback from './ErrorFallback';
 
@@ -14,23 +14,34 @@ type CodeEditorProps = {
 export const CodeEditor: React.FunctionComponent<CodeEditorProps> = (props) => {
   const maxStringLength = 10000;
   const valueLength = props.value?.length;
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
   const [loadAll, setLoadAll] = useState(valueLength < maxStringLength);
   const [loadedValue, setLoadedValue] = useState(
     loadAll ? props.value : props.value?.slice(0, maxStringLength) + '...'
   );
+  const [editorHeight, setEditorHeight] = useState(48);
 
   const onLoadAll = () => {
     setLoadedValue(props.value);
     setLoadAll(true);
   };
 
+  const changeEditorHeight = () => {
+    const newContentHeight = editorRef.current.getContentHeight();
+    if (editorHeight !== newContentHeight) {
+      setEditorHeight(newContentHeight);
+    }
+  };
+
   const editorDidMount = (editor) => {
     console.log('editorDidMount', editor);
-    editor.focus();
+    editorRef.current = editor;
+    changeEditorHeight();
+    editorRef.current.focus();
   };
 
   const onChange = (value, e) => {
-    // console.log(value);
+    changeEditorHeight();
     setLoadedValue(value);
     props.onChange(value);
   };
@@ -51,7 +62,7 @@ export const CodeEditor: React.FunctionComponent<CodeEditorProps> = (props) => {
         )}
         <MonacoEditor
           width="100%"
-          height="600"
+          height={`clamp(48px, ${editorHeight}px, 60vh)`}
           language="javascript"
           theme="vs-dark"
           value={loadedValue}
@@ -60,7 +71,7 @@ export const CodeEditor: React.FunctionComponent<CodeEditorProps> = (props) => {
             lineNumbersMinChars: 4,
             minimap: { enabled: !loadAll },
             readOnly: !loadAll || !props.editable,
-            // scrollBeyondLastLine: false,
+            scrollBeyondLastLine: false,
             selectOnLineNumbers: true,
             tabSize: 2,
             wordWrap: 'on',

--- a/src/utils/style.module.css
+++ b/src/utils/style.module.css
@@ -237,7 +237,7 @@
 }
 
 .propertyContainerContent {
-  max-height: 40vh;
+  max-height: 60vh;
   overflow: auto;
 }
 


### PR DESCRIPTION
This should fix the issue with the code editor height in the side bar. The editor is now resized based on content height with a minimum and a maximum value.

<img width="323" alt="Screen Shot 2022-08-16 at 19 01 17" src="https://user-images.githubusercontent.com/4619772/184937112-7560cf99-ac6e-4dce-92e7-39ac3ccf9ac4.png">

