### PR TITLE
Drag link on node

### DIFF
--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -448,10 +448,7 @@ export default class PPGraph {
           'of',
           node.inputSocketArray[0].parent.name
         );
-        const index = getMatchingSocketIndex(
-          customArgs.addLink,
-          node.inputSocketArray
-        );
+        const index = getMatchingSocketIndex(customArgs.addLink, node);
         this.connect(customArgs.addLink, node.inputSocketArray[index], notify);
         this.clearTempConnection();
       } else if (
@@ -468,10 +465,7 @@ export default class PPGraph {
           'of',
           node.outputSocketArray[0].parent.name
         );
-        const index = getMatchingSocketIndex(
-          customArgs.addLink,
-          node.outputSocketArray
-        );
+        const index = getMatchingSocketIndex(customArgs.addLink, node);
         this.connect(node.outputSocketArray[index], customArgs.addLink, notify);
       }
     }

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -38,6 +38,7 @@ import PPGraph from './GraphClass';
 import Socket from './SocketClass';
 import {
   calculateAspectRatioFit,
+  getMatchingSocketIndex,
   getNodeCommentPosX,
   getNodeCommentPosY,
 } from '../utils/utils';
@@ -1177,8 +1178,8 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     this.onMoveHandler = this._onPointerMove.bind(this);
 
     this.on('pointerdown', this._onPointerDown.bind(this));
-    this.on('pointerup', this._onPointerUpAndUpOutside.bind(this));
-    this.on('pointerupoutside', this._onPointerUpAndUpOutside.bind(this));
+    this.on('pointerup', this._onPointerUp.bind(this));
+    this.on('pointerupoutside', this._onPointerUpOutside.bind(this));
     this.on('pointerover', this._onPointerOver.bind(this));
     this.on('pointerout', this._onPointerOut.bind(this));
     this.on('dblclick', this._onDoubleClick.bind(this));
@@ -1220,7 +1221,30 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     }
   }
 
-  _onPointerUpAndUpOutside(): void {
+  _onPointerUp(): void {
+    const source = PPGraph.currentGraph.selectedSourceSocket;
+    if (source) {
+      PPGraph.currentGraph.selectedSourceSocket = null;
+      if (this !== source.getNode()) {
+        if (source.socketType === SOCKET_TYPE.IN) {
+          // await PPGraph.currentGraph.connect(socket, source);
+        } else {
+          const index = getMatchingSocketIndex(source, this);
+          PPGraph.currentGraph.connect(source, this.inputSocketArray[index]);
+        }
+      }
+    }
+
+    // unsubscribe from pointermove
+    this.removeListener('pointermove', this.onMoveHandler);
+
+    this.alpha = 1;
+    this.isDraggingNode = false;
+    this.onNodeDragging(this.isDraggingNode);
+    this.cursor = 'move';
+  }
+
+  _onPointerUpOutside(): void {
     // unsubscribe from pointermove
     this.removeListener('pointermove', this.onMoveHandler);
 

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -298,6 +298,10 @@ export default class PPNode extends PIXI.Container {
     return undefined;
   }
 
+  getPreferredOutputSocketIndex(): number | undefined {
+    return undefined;
+  }
+
   addInput(
     name: string,
     type: AbstractType, // but really its AbstractType
@@ -1239,10 +1243,15 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
       PPGraph.currentGraph.selectedSourceSocket = null;
       if (this !== source.getNode()) {
         if (source.socketType === SOCKET_TYPE.IN) {
-          // await PPGraph.currentGraph.connect(socket, source);
+          const index = getMatchingSocketIndex(source, this, true);
+          if (index !== undefined) {
+            PPGraph.currentGraph.connect(this.outputSocketArray[index], source);
+          }
         } else {
           const index = getMatchingSocketIndex(source, this);
-          PPGraph.currentGraph.connect(source, this.inputSocketArray[index]);
+          if (index !== undefined) {
+            PPGraph.currentGraph.connect(source, this.inputSocketArray[index]);
+          }
         }
       }
     }

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -1221,7 +1221,19 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     }
   }
 
+  commonPointerUp(): void {
+    // unsubscribe from pointermove
+    this.removeListener('pointermove', this.onMoveHandler);
+
+    this.alpha = 1;
+    this.isDraggingNode = false;
+    this.onNodeDragging(this.isDraggingNode);
+    this.cursor = 'move';
+  }
+
   _onPointerUp(): void {
+    this.commonPointerUp();
+
     const source = PPGraph.currentGraph.selectedSourceSocket;
     if (source) {
       PPGraph.currentGraph.selectedSourceSocket = null;
@@ -1234,24 +1246,10 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
         }
       }
     }
-
-    // unsubscribe from pointermove
-    this.removeListener('pointermove', this.onMoveHandler);
-
-    this.alpha = 1;
-    this.isDraggingNode = false;
-    this.onNodeDragging(this.isDraggingNode);
-    this.cursor = 'move';
   }
 
   _onPointerUpOutside(): void {
-    // unsubscribe from pointermove
-    this.removeListener('pointermove', this.onMoveHandler);
-
-    this.alpha = 1;
-    this.isDraggingNode = false;
-    this.onNodeDragging(this.isDraggingNode);
-    this.cursor = 'move';
+    this.commonPointerUp();
   }
 
   public _onPointerMove(): void {

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -293,6 +293,10 @@ export default class PPNode extends PIXI.Container {
     return new AnyType();
   }
 
+  getPreferredInputSocketIndex(): number | undefined {
+    return undefined;
+  }
+
   addInput(
     name: string,
     type: AbstractType, // but really its AbstractType

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -294,12 +294,12 @@ export default class PPNode extends PIXI.Container {
     return new AnyType();
   }
 
-  getPreferredInputSocketIndex(): number | undefined {
-    return undefined;
+  getPreferredInputSocketName(): string {
+    return 'MyPreferredInputSocket';
   }
 
-  getPreferredOutputSocketIndex(): number | undefined {
-    return undefined;
+  getPreferredOutputSocketName(): string {
+    return 'MyPreferredOutputSocket';
   }
 
   addInput(

--- a/src/nodes/base.ts
+++ b/src/nodes/base.ts
@@ -106,8 +106,8 @@ export class Mouse extends PPNode {
 }
 
 export class Keyboard extends PPNode {
-  onKeyDownHandler: (event?: KeyboardEvent) => void = () => { };
-  onKeyUpHandler: (event?: KeyboardEvent) => void = () => { };
+  onKeyDownHandler: (event?: KeyboardEvent) => void = () => {};
+  onKeyUpHandler: (event?: KeyboardEvent) => void = () => {};
   _onKeyDown = (event: KeyboardEvent): void => {
     this.setOutputData('key', event.key);
     this.setOutputData('code', event.code);
@@ -430,7 +430,7 @@ export class If_Else extends PPNode {
 
   protected getDefaultIO(): PPSocket[] {
     return [
-      new PPSocket(SOCKET_TYPE.IN, 'Condition', new AnyType(), 0),
+      new PPSocket(SOCKET_TYPE.IN, 'Condition', new BooleanType(), false),
       new PPSocket(SOCKET_TYPE.IN, 'A', new AnyType(), 'A'),
       new PPSocket(SOCKET_TYPE.IN, 'B', new AnyType(), 'B'),
       new PPSocket(SOCKET_TYPE.OUT, 'Output', new AnyType()),

--- a/src/nodes/logViewer.tsx
+++ b/src/nodes/logViewer.tsx
@@ -102,8 +102,4 @@ export class LogViewer extends PPNode {
   protected getActivateByDoubleClick(): boolean {
     return true;
   }
-
-  getPreferredInputSocketIndex(): number {
-    return 0;
-  }
 }

--- a/src/nodes/logViewer.tsx
+++ b/src/nodes/logViewer.tsx
@@ -102,4 +102,8 @@ export class LogViewer extends PPNode {
   protected getActivateByDoubleClick(): boolean {
     return true;
   }
+
+  getPreferredInputSocketIndex(): number {
+    return 0;
+  }
 }

--- a/src/nodes/table.tsx
+++ b/src/nodes/table.tsx
@@ -41,8 +41,12 @@ export class Table extends PPNode {
     return true;
   }
 
+  getPreferredInputSocketIndex(): number {
+    return 1;
+  }
+
   getPreferredOutputSocketIndex(): number {
-    return 3;
+    return 2;
   }
 
   public getName(): string {

--- a/src/nodes/table.tsx
+++ b/src/nodes/table.tsx
@@ -40,6 +40,11 @@ export class Table extends PPNode {
   protected getActivateByDoubleClick(): boolean {
     return true;
   }
+
+  getPreferredOutputSocketIndex(): number {
+    return 3;
+  }
+
   public getName(): string {
     return 'Table';
   }

--- a/src/nodes/table.tsx
+++ b/src/nodes/table.tsx
@@ -41,12 +41,12 @@ export class Table extends PPNode {
     return true;
   }
 
-  getPreferredInputSocketIndex(): number {
-    return 1;
+  getPreferredInputSocketName(): string {
+    return sheetIndexInputSocketName;
   }
 
-  getPreferredOutputSocketIndex(): number {
-    return 2;
+  getPreferredOutputSocketName(): string {
+    return JSONSocketName;
   }
 
   public getName(): string {

--- a/src/nodes/text.tsx
+++ b/src/nodes/text.tsx
@@ -33,8 +33,8 @@ export class Label extends PPNode {
     return true;
   }
 
-  getPreferredInputSocketIndex(): number {
-    return 0;
+  getPreferredInputSocketName(): string {
+    return 'Input';
   }
 
   public getName(): string {

--- a/src/nodes/text.tsx
+++ b/src/nodes/text.tsx
@@ -21,6 +21,22 @@ export class Label extends PPNode {
   currentInput: HTMLDivElement;
   createInputElement: () => void;
 
+  getShowLabels(): boolean {
+    return false;
+  }
+
+  getRoundedCorners(): boolean {
+    return false;
+  }
+
+  shouldExecuteOnMove(): boolean {
+    return true;
+  }
+
+  getPreferredInputSocketIndex(): number {
+    return 0;
+  }
+
   public getName(): string {
     return 'Label';
   }
@@ -243,17 +259,5 @@ export class Label extends PPNode {
     this.onNodeRemoved = () => {
       this._refText.destroy();
     };
-  }
-
-  getShowLabels(): boolean {
-    return false;
-  }
-
-  getRoundedCorners(): boolean {
-    return false;
-  }
-
-  shouldExecuteOnMove(): boolean {
-    return true;
   }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -562,19 +562,17 @@ export const getMatchingSocketIndex = (
   socket: PPSocket,
   node: PPNode
 ): number => {
+  // if the node has a preferredInputSocket (with no connection), use it
   const preferredIndex = node.getPreferredInputSocketIndex();
   if (preferredIndex !== undefined) {
     const hasLink = node.inputSocketArray[preferredIndex].hasLink();
-
-    // if socket does not have a link return index
-    // else look for another match below
     if (!hasLink) {
       return preferredIndex;
     }
   }
 
+  // if the node has a socket with the same type (with no connection), use it
   const indexExactMatch = node.inputSocketArray.findIndex((socketInArray) => {
-    // if socket has link, check next one
     return (
       !socketInArray.hasLink() &&
       socketInArray.dataType.constructor === socket.dataType.constructor
@@ -585,13 +583,23 @@ export const getMatchingSocketIndex = (
     return indexExactMatch;
   }
 
-  const index = node.inputSocketArray.findIndex((socketInArray) => {
-    // if socket has link, check next one
+  // if the node has a socket with the AnyType (with no connection), use it
+  const indexAnyType = node.inputSocketArray.findIndex((socketInArray) => {
     return (
       !socketInArray.hasLink() &&
       socketInArray.dataType.constructor === new AnyType().constructor
     );
   });
 
-  return index > -1 ? index : 0; // take the first index (0) if none was found
+  if (indexAnyType > -1) {
+    return indexAnyType;
+  }
+
+  // if the node has a socket (with no connection), use it
+  const index = node.inputSocketArray.findIndex((socketInArray) => {
+    return !socketInArray.hasLink();
+  });
+
+  // if the node is full, use preferredInputSocket or first index
+  return index > -1 ? index : preferredIndex ?? 0;
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -560,18 +560,37 @@ export const isVariable = (
 
 export const getMatchingSocketIndex = (
   socket: PPSocket,
-  socketArray: PPSocket[]
+  node: PPNode
 ): number => {
-  const indexExactMatch = socketArray.findIndex((socketInArray) => {
-    return socketInArray.dataType.constructor === socket.dataType.constructor;
+  const preferredIndex = node.getPreferredInputSocketIndex();
+  if (preferredIndex !== undefined) {
+    const hasLink = node.inputSocketArray[preferredIndex].hasLink();
+
+    // if socket does not have a link return index
+    // else look for another match below
+    if (!hasLink) {
+      return preferredIndex;
+    }
+  }
+
+  const indexExactMatch = node.inputSocketArray.findIndex((socketInArray) => {
+    // if socket has link, check next one
+    return (
+      !socketInArray.hasLink() &&
+      socketInArray.dataType.constructor === socket.dataType.constructor
+    );
   });
 
   if (indexExactMatch > -1) {
     return indexExactMatch;
   }
 
-  const index = socketArray.findIndex((socketInArray) => {
-    return socketInArray.dataType.constructor === new AnyType().constructor;
+  const index = node.inputSocketArray.findIndex((socketInArray) => {
+    // if socket has link, check next one
+    return (
+      !socketInArray.hasLink() &&
+      socketInArray.dataType.constructor === new AnyType().constructor
+    );
   });
 
   return index > -1 ? index : 0; // take the first index (0) if none was found


### PR DESCRIPTION
This feature allows you to drag connections from inputs or outputs directly onto another node.  In addition I have also added both preferred input and output socket index. The logic is:
* if node has a preferred socket index without connection > use it
* if node has a socket with the same type without connection > use it
* if node has a AnyType socket without connection > use it
* if node has a socket without connection > use it
* if all sockets have connections, connect to preferred socket, else connect to first socket

I have gone through some of the nodes and added preferred sockets were I thought it fits.