### PR TITLE
Move trigger sockets out of socket array

### DIFF
--- a/src/PropertyArrayContainer.tsx
+++ b/src/PropertyArrayContainer.tsx
@@ -63,6 +63,34 @@ export const PropertyArrayContainer: React.FunctionComponent<
 > = (props) => {
   return (
     <Stack spacing={1}>
+      {props.selectedNode.nodeTriggerSocketArray?.length > 0 && (
+        <StyledAccordion defaultExpanded>
+          <StyledAccordionSummary>
+            <Box textAlign="left" sx={{ color: 'text.primary' }}>
+              NODE TRIGGER
+            </Box>
+          </StyledAccordionSummary>
+          <StyledAccordionDetails>
+            {props.selectedNode.nodeTriggerSocketArray?.map(
+              (property, index) => {
+                return (
+                  <PropertyContainer
+                    key={index}
+                    property={property}
+                    index={index}
+                    dataType={property.dataType}
+                    isInput={true}
+                    hasLink={property.hasLink()}
+                    data={property.data}
+                    randomMainColor={props.randomMainColor}
+                    selectedNode={props.selectedNode}
+                  />
+                );
+              }
+            )}
+          </StyledAccordionDetails>
+        </StyledAccordion>
+      )}
       {props.selectedNode.inputSocketArray?.length > 0 && (
         <StyledAccordion defaultExpanded>
           <StyledAccordionSummary>

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -658,12 +658,6 @@ export default class PPGraph {
     this.selection.selectedNodes.forEach((node) => node.addTriggerInput());
   }
 
-  addInput(): void {
-    this.selection.selectedNodes
-      .filter((node) => node.getCanAddInput())
-      .forEach((node) => node.addDefaultInput());
-  }
-
   getCanAddOutput(): boolean {
     return !this.selection.selectedNodes.find(
       (node) => !node.getCanAddOutput()

--- a/src/classes/SocketClass.ts
+++ b/src/classes/SocketClass.ts
@@ -14,6 +14,7 @@ import {
   NODE_WIDTH,
 } from '../utils/constants';
 import { AbstractType } from '../nodes/datatypes/abstractType';
+import { TriggerType } from '../nodes/datatypes/triggerType';
 import { serializeType } from '../nodes/datatypes/typehelper';
 
 export default class Socket extends PIXI.Container {
@@ -104,7 +105,9 @@ export default class Socket extends PIXI.Container {
       SOCKET_WIDTH / 2,
       SOCKET_WIDTH,
       SOCKET_WIDTH,
-      SOCKET_CORNERRADIUS
+      this.dataType.constructor === new TriggerType().constructor
+        ? 0
+        : SOCKET_CORNERRADIUS
     );
     this._SocketRef.endFill();
     this._SocketRef.name = 'SocketRef';

--- a/src/nodes/data/dataFunctions.tsx
+++ b/src/nodes/data/dataFunctions.tsx
@@ -322,7 +322,7 @@ export class CustomFunction extends PPNode {
   adaptInputs(code: string): void {
     const codeArguments = getArgumentsFromFunction(code);
     // remove all non existing arguments and add all missing (based on the definition we just got)
-    const currentInputSockets = this.getAllSockets().filter(
+    const currentInputSockets = this.getAllSockets(false).filter(
       (socket) => socket.socketType === SOCKET_TYPE.IN
     );
     const socketsToBeRemoved = currentInputSockets.filter(

--- a/src/nodes/data/dataFunctions.tsx
+++ b/src/nodes/data/dataFunctions.tsx
@@ -322,7 +322,7 @@ export class CustomFunction extends PPNode {
   adaptInputs(code: string): void {
     const codeArguments = getArgumentsFromFunction(code);
     // remove all non existing arguments and add all missing (based on the definition we just got)
-    const currentInputSockets = this.getAllSockets(false).filter(
+    const currentInputSockets = this.getDataSockets().filter(
       (socket) => socket.socketType === SOCKET_TYPE.IN
     );
     const socketsToBeRemoved = currentInputSockets.filter(

--- a/src/nodes/widgets/widgetNodes.tsx
+++ b/src/nodes/widgets/widgetNodes.tsx
@@ -127,7 +127,6 @@ export class WidgetButton extends PPNode {
         const inputData = this.getInputData(offValueName);
         this.setOutputData(outName, inputData);
         this.executeChildren();
-        console.log(props.randomMainColor);
       };
 
       return (

--- a/src/utils/interfaces.tsx
+++ b/src/utils/interfaces.tsx
@@ -83,6 +83,7 @@ export type SerializedNode = {
   height: number;
   minWidth: number;
   minHeight?: number;
+  triggerArray: SerializedSocket[];
   socketArray: SerializedSocket[];
   updateBehaviour: IUpdateBehaviour;
 };


### PR DESCRIPTION
* I have introduced a nodeTriggerSocketArray, which is being used if you right click add a node trigger socket
  * Though it is still possible to use triggerType on normal inputs
  * The node trigger sockets are displayed on the top before the outputs
* I have updated the look of trigger types to be square
* I have updated the addTriggerInput function to also turn off "Update on change" as this is probably always what you want when adding a nodeTriggerSocket

<img width="742" alt="Screen Shot 2022-09-27 at 21 52 10" src="https://user-images.githubusercontent.com/4619772/192622546-8879b71a-b996-46f6-bf1d-f493d883f0f6.png">
