### PR TITLE
node-updates-2

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,8 +176,10 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     console.log(acceptedFiles, fileRejections);
 
     const dropPoint = viewport.current.toWorld(
-      new PIXI.Point(event.clientX, event.clientY)
+      // no event exists in case graph gets loaded from file
+      new PIXI.Point(event?.clientX ?? 0, event?.clientY ?? 0)
     );
+
     let nodePosX = dropPoint.x;
     const nodePosY = dropPoint.y;
     const newNodeSelection: PPNode[] = [];
@@ -221,10 +223,10 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
             break;
           case 'txt':
             data = await response.text();
-            newNode = currentGraph.current.addNewNode('Text', {
+            newNode = currentGraph.current.addNewNode('TextEditor', {
               nodePosX,
               nodePosY,
-              initialData: data,
+              initialData: { plain: data },
             });
             break;
           case 'jpg':
@@ -553,6 +555,8 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
         return Math.min(window.innerHeight - offset, event.data.global.y);
       };
       switch (true) {
+        case target.parent instanceof PPSocket &&
+          target instanceof PIXI.Graphics:
         case target.parent instanceof PPSocket && target instanceof PIXI.Text:
           console.log('app right click, socket');
           setContextMenuPosition([contextMenuPosX, contextMenuPosY(80)]);

--- a/src/InspectorContainer.tsx
+++ b/src/InspectorContainer.tsx
@@ -63,6 +63,7 @@ const InspectorContainer: React.FunctionComponent<MyProps> = (props) => {
               display: 'inline-flex',
               alignItems: 'center',
             }}
+            title={props.selectedNode?.id}
           >
             {props.selectedNode?.name}
           </Box>

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -134,7 +134,6 @@ export default class PPGraph {
     console.log('GraphClass - _onPointerRightClicked');
     event.stopPropagation();
     const target = event.target;
-    console.log(target, event.data.originalEvent);
     if (
       // only trigger right click if viewport was not dragged
       this.dragSourcePoint === undefined ||
@@ -284,9 +283,7 @@ export default class PPGraph {
   }
 
   socketMouseDown(socket: PPSocket, event: PIXI.InteractionEvent): void {
-    if (event.data.button === 2) {
-      socket.links.forEach((link) => this.action_Disconnect(link));
-    } else if (socket.socketType === SOCKET_TYPE.OUT) {
+    if (socket.socketType === SOCKET_TYPE.OUT) {
       this.selectedSourceSocket = socket;
       this.lastSelectedSocketWasInput = false;
     } else {
@@ -310,7 +307,7 @@ export default class PPGraph {
   ): Promise<void> {
     const source = this.selectedSourceSocket;
     this.selectedSourceSocket = null;
-    if (socket !== this.selectedSourceSocket) {
+    if (source && socket !== this.selectedSourceSocket) {
       if (
         source.socketType === SOCKET_TYPE.IN &&
         socket.socketType === SOCKET_TYPE.OUT
@@ -593,6 +590,7 @@ export default class PPGraph {
       newNode = await this.addNewNode(nodeType, {
         nodePosX: node.x,
         nodePosY: node.y + socket.y,
+        initialData: socket.data,
       });
       newNode.setPosition(-(newNode.width + 40), 0, true);
     } else {

--- a/src/classes/SocketClass.ts
+++ b/src/classes/SocketClass.ts
@@ -25,7 +25,7 @@ export default class Socket extends PIXI.Container {
   // data is derived from execute function
 
   _SocketRef: PIXI.Graphics;
-  _TextRef: PIXI.Graphics;
+  _TextRef: PIXI.Text;
 
   _socketType: TSocketType;
   _dataType: AbstractType;
@@ -82,7 +82,7 @@ export default class Socket extends PIXI.Container {
     this.removeChild(this._SocketRef);
     this.removeChild(this._TextRef);
     this._SocketRef = new PIXI.Graphics();
-    this._TextRef = new PIXI.Graphics();
+    this._TextRef = new PIXI.Text();
     this._SocketRef.beginFill(this.dataType.getColor().hexNumber());
     this._SocketRef.drawRoundedRect(
       this.getSocketLocation().x,
@@ -95,27 +95,26 @@ export default class Socket extends PIXI.Container {
     );
 
     if (this.showLabel) {
-      const socketNameText = new PIXI.Text(this.name, SOCKET_TEXTSTYLE);
+      this._TextRef = new PIXI.Text(this.name, SOCKET_TEXTSTYLE);
       if (this.socketType === SOCKET_TYPE.OUT) {
-        socketNameText.anchor.set(1, 0);
+        this._TextRef.anchor.set(1, 0);
+        this._TextRef.name = 'TextRef';
       }
-      socketNameText.x =
+      this._TextRef.x =
         this.socketType === SOCKET_TYPE.IN
           ? SOCKET_WIDTH + SOCKET_TEXTMARGIN
           : this.getNode()?.nodeWidth - SOCKET_TEXTMARGIN;
-      socketNameText.y = SOCKET_TEXTMARGIN_TOP;
-      socketNameText.resolution = TEXT_RESOLUTION;
+      this._TextRef.y = SOCKET_TEXTMARGIN_TOP;
+      this._TextRef.resolution = TEXT_RESOLUTION;
 
-      socketNameText.interactive = true;
-      socketNameText.on('pointerover', this._onPointerOver.bind(this));
-      socketNameText.on('pointerout', this._onPointerOut.bind(this));
-      socketNameText.on('pointerdown', (event) => {
+      this._TextRef.interactive = true;
+      this._TextRef.on('pointerover', this._onPointerOver.bind(this));
+      this._TextRef.on('pointerout', this._onPointerOut.bind(this));
+      this._TextRef.on('pointerdown', (event) => {
         if (event.data.button !== 2) {
           this.getGraph().socketNameRefMouseDown(this, event);
         }
       });
-
-      this._TextRef.addChild(socketNameText);
     }
 
     this._SocketRef.endFill();

--- a/src/components/ContextMenus.tsx
+++ b/src/components/ContextMenus.tsx
@@ -469,6 +469,23 @@ export const SocketContextMenu = (props) => {
       }}
     >
       <MenuList dense>
+        {selectedSocket.hasLink() && (
+          <>
+            <MenuItem
+              onClick={() => {
+                selectedSocket.links.forEach((link) =>
+                  props.currentGraph.current.action_Disconnect(link)
+                );
+              }}
+            >
+              <ListItemIcon>
+                <DeleteIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>Remove connection</ListItemText>
+            </MenuItem>
+            <Divider />
+          </>
+        )}
         {selectedSocket.isInput() && (
           <MenuItem
             onClick={() => {
@@ -478,7 +495,9 @@ export const SocketContextMenu = (props) => {
             <ListItemIcon>
               <AddIcon fontSize="small" />
             </ListItemIcon>
-            <ListItemText>Connect widget node</ListItemText>
+            <ListItemText>
+              Connect {selectedSocket.dataType.defaultInputNodeWidget()}
+            </ListItemText>
           </MenuItem>
         )}
         {!selectedSocket.isInput() && (
@@ -490,7 +509,9 @@ export const SocketContextMenu = (props) => {
             <ListItemIcon>
               <AddIcon fontSize="small" />
             </ListItemIcon>
-            <ListItemText>Connect label node</ListItemText>
+            <ListItemText>
+              Connect {selectedSocket.dataType.defaultOutputNodeWidget()}
+            </ListItemText>
           </MenuItem>
         )}
         {isDeletable && (

--- a/src/nodes/base.ts
+++ b/src/nodes/base.ts
@@ -78,7 +78,7 @@ export class Mouse extends PPNode {
     ].concat(super.getDefaultIO());
   }
 
-  public onNodeAdded () :void {
+  public onNodeAdded(): void {
     super.onNodeAdded();
     // add event listener
     this.onViewportMoveHandler = this.onViewportMove.bind(this);
@@ -92,7 +92,7 @@ export class Mouse extends PPNode {
       'zoomed',
       (this as any).onViewportZoomedHandler
     );
-  };
+  }
 
   onNodeRemoved = (): void => {
     PPGraph.currentGraph.viewport.removeListener(
@@ -162,14 +162,14 @@ export class Keyboard extends PPNode {
       ),
     ].concat(super.getDefaultIO());
   }
-  public onNodeAdded () :void {
+  public onNodeAdded(): void {
     super.onNodeAdded();
     // add event listener
     this.onKeyDownHandler = this._onKeyDown.bind(this);
     window.addEventListener('keydown', (this as any).onKeyDownHandler);
     this.onKeyUpHandler = this._onKeyUp.bind(this);
     window.addEventListener('keyup', (this as any).onKeyUpHandler);
-  };
+  }
 
   onNodeRemoved = (): void => {
     window.removeEventListener('keydown', this.onKeyDownHandler);
@@ -363,26 +363,16 @@ export class RandomArray extends PPNode {
 }
 
 export class DateAndTime extends PPNode {
-  getColor(): TRgba {
-    return TRgba.fromString(NODE_TYPE_COLOR.INPUT);
-  }
-  constructor(name: string, customArgs: CustomArgs) {
-    super(name, {
-      ...customArgs,
-    });
-
-    this.onExecute = async function (input, output) {
-      const dateMethod = input['Date method'];
-      output['date and time'] = new Date()[dateMethod]();
-    };
-  }
-
   public getName(): string {
     return 'Date and time';
   }
 
   public getDescription(): string {
-    return 'Outputs current time in different formats';
+    return 'Outputs time in different formats';
+  }
+
+  getColor(): TRgba {
+    return TRgba.fromString(NODE_TYPE_COLOR.INPUT);
   }
 
   protected getDefaultIO(): PPSocket[] {
@@ -404,7 +394,8 @@ export class DateAndTime extends PPNode {
       });
 
     return [
-      new PPSocket(SOCKET_TYPE.OUT, 'date and time', new StringType()),
+      new PPSocket(SOCKET_TYPE.OUT, 'Date and time', new StringType()),
+      new PPSocket(SOCKET_TYPE.IN, 'Date string', new StringType(), '', false),
       new PPSocket(
         SOCKET_TYPE.IN,
         'Date method',
@@ -413,6 +404,16 @@ export class DateAndTime extends PPNode {
         false
       ),
     ].concat(super.getDefaultIO());
+  }
+
+  protected async onExecute(
+    inputObject: any,
+    outputObject: Record<string, unknown>
+  ): Promise<void> {
+    const dateString = inputObject['Date string'];
+    const dateMethod = inputObject['Date method'];
+    const dateObject = dateString === '' ? new Date() : new Date(dateString);
+    outputObject['Date and time'] = dateObject[dateMethod]();
   }
 }
 

--- a/src/nodes/data/dataFunctions.tsx
+++ b/src/nodes/data/dataFunctions.tsx
@@ -89,6 +89,8 @@ export class ConcatenateArrays extends PPNode {
 }
 
 export class Constant extends PPNode {
+  initialData: any;
+
   protected getDefaultIO(): Socket[] {
     return [
       new Socket(SOCKET_TYPE.IN, constantInName, new AnyType(), 0),
@@ -100,6 +102,21 @@ export class Constant extends PPNode {
     outputObject: Record<string, unknown>
   ): Promise<void> {
     outputObject[constantOutName] = inputObject?.[constantInName];
+  }
+
+  constructor(name: string, customArgs?: CustomArgs) {
+    super(name, {
+      ...customArgs,
+    });
+
+    this.initialData = customArgs?.initialData;
+
+    this.onNodeAdded = () => {
+      if (this.initialData) {
+        this.setInputData(constantInName, this.initialData);
+      }
+      super.onNodeAdded();
+    };
   }
 }
 

--- a/src/nodes/datatypes/codeType.tsx
+++ b/src/nodes/datatypes/codeType.tsx
@@ -27,4 +27,8 @@ export class CodeType extends AbstractType {
   defaultInputNodeWidget(): undefined | string {
     return 'CodeEditor';
   }
+
+  defaultOutputNodeWidget(): string {
+    return 'CodeEditor';
+  }
 }

--- a/src/nodes/datatypes/jsonType.tsx
+++ b/src/nodes/datatypes/jsonType.tsx
@@ -47,4 +47,12 @@ export class JSONType extends AbstractType {
     }
     return data;
   }
+
+  defaultInputNodeWidget(): string {
+    return 'CodeEditor';
+  }
+
+  defaultOutputNodeWidget(): string {
+    return 'CodeEditor';
+  }
 }

--- a/src/nodes/datatypes/stringType.tsx
+++ b/src/nodes/datatypes/stringType.tsx
@@ -25,4 +25,8 @@ export class StringType extends AbstractType {
   getColor(): TRgba {
     return new TRgba(128, 250, 128);
   }
+
+  defaultInputNodeWidget(): string {
+    return 'Label';
+  }
 }

--- a/src/nodes/text.tsx
+++ b/src/nodes/text.tsx
@@ -19,6 +19,7 @@ export class Label extends PPNode {
   _refText: PIXI.Text;
   _refTextStyle: PIXI.TextStyle;
   currentInput: HTMLDivElement;
+  initialData: any;
   createInputElement: () => void;
 
   getShowLabels(): boolean {
@@ -89,6 +90,8 @@ export class Label extends PPNode {
       nodeWidth,
     });
 
+    this.initialData = customArgs?.initialData;
+
     const canvas = PPGraph.currentGraph.foregroundCanvas;
     this._refTextStyle = new PIXI.TextStyle();
     const basicText = new PIXI.Text('', this._refTextStyle);
@@ -97,6 +100,9 @@ export class Label extends PPNode {
 
     // when the Node is added, focus it so one can start writing
     this.onNodeAdded = () => {
+      if (this.initialData) {
+        this.setInputData('Input', this.initialData);
+      }
       this.currentInput = null;
       this.createInputElement();
       super.onNodeAdded();

--- a/src/nodes/textEditor/slate-editor-components.tsx
+++ b/src/nodes/textEditor/slate-editor-components.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
-import { Editor, Range, Transforms, Element as SlateElement } from 'slate';
+import {
+  Editor,
+  Node,
+  Range,
+  Transforms,
+  Element as SlateElement,
+} from 'slate';
 import { useFocused, useSelected, useReadOnly } from 'slate-react';
 import { jsx } from 'slate-hyperscript';
 import { Typography, styled } from '@mui/material';
@@ -564,4 +570,8 @@ const Mention = (props) => {
       {children}@{element.inputName}
     </span>
   );
+};
+
+export const getPlainText = (nodes) => {
+  return nodes.map((n) => Node.string(n)).join('\n');
 };

--- a/src/nodes/textEditor/textEditor.tsx
+++ b/src/nodes/textEditor/textEditor.tsx
@@ -90,6 +90,10 @@ export class TextEditor extends HybridNode {
     );
   }
 
+  getPreferredOutputSocketName(): string {
+    return textOutputSocketName;
+  }
+
   protected getDefaultIO(): PPSocket[] {
     const backgroundColor = COLOR[8];
 

--- a/src/nodes/textEditor/textEditor.tsx
+++ b/src/nodes/textEditor/textEditor.tsx
@@ -28,6 +28,7 @@ import {
   Element,
   Leaf,
   deserialize,
+  getPlainText,
   insertMention,
   moveBlock,
   toggleBlock,
@@ -41,6 +42,7 @@ import { BooleanType } from '../datatypes/booleanType';
 import { ColorType } from '../datatypes/colorType';
 import { JSONType } from '../datatypes/jsonType';
 import HybridNode from '../../classes/HybridNode';
+import { StringType } from '../datatypes/stringType';
 
 const isMac = navigator.platform.indexOf('Mac') != -1;
 
@@ -51,9 +53,10 @@ const initialValue: Descendant[] = [
   },
 ];
 
-const outputSocketName = 'output';
+const outputSocketName = 'Output';
+const textOutputSocketName = 'Plain text';
 const textJSONSocketName = 'textJSON';
-const backgroundColorSocketName = 'background Color';
+const backgroundColorSocketName = 'Background Color';
 const autoHeightName = 'Auto height';
 const inputPrefix = 'Input';
 const inputName1 = `${inputPrefix} 1`;
@@ -69,7 +72,7 @@ export class TextEditor extends HybridNode {
   }
 
   public getName(): string {
-    return 'Rich text editor';
+    return 'Text editor';
   }
 
   public getDescription(): string {
@@ -95,6 +98,13 @@ export class TextEditor extends HybridNode {
         SOCKET_TYPE.OUT,
         outputSocketName,
         new JSONType(),
+        undefined,
+        false
+      ),
+      new PPSocket(
+        SOCKET_TYPE.OUT,
+        textOutputSocketName,
+        new StringType(),
         undefined,
         true
       ),
@@ -141,10 +151,6 @@ export class TextEditor extends HybridNode {
 
   public getDefaultNodeWidth(): number {
     return 400;
-  }
-
-  public getDefaultNodeHeight(): number {
-    return 300;
   }
 
   constructor(name: string, customArgs?: CustomArgs) {
@@ -197,6 +203,7 @@ export class TextEditor extends HybridNode {
         readOnly: this.readOnly,
         textToImport: this.textToImport,
       });
+      super.onNodeAdded();
     };
 
     this.update = (newHeight): void => {
@@ -395,6 +402,7 @@ export class TextEditor extends HybridNode {
         // update in and outputs
         this.setInputData(textJSONSocketName, value);
         this.setOutputData(outputSocketName, value);
+        this.setOutputData(textOutputSocketName, getPlainText(value));
         this.executeChildren();
       };
 


### PR DESCRIPTION
* When right clicking a socket or its name, you can connect a node. Now, if it is an input socket, the data is transferred over to the new node. This way you can break out data into separate nodes. This also works when there was a previous connection.
  * Before the right clicking was only possible on the text. As hybrid nodes do not have a text, I have removed the "right click a socket removes the link" and moved it into the context menu. This might be controversial, but I was not sure how else to do this
  * Added more defaultInput/OutputWidget definitions for some types
  * Added option for Label, Constant node to receive initial data
* Added optional date string input for DateAndTime node
* Added plain text output for TextEditor
* Fixed txt import
* Fixed socket right click no longer working due to hierarchy change in the socket

https://user-images.githubusercontent.com/4619772/198852007-b572716f-1d64-4efd-bda7-7f30414cd748.mp4
