### PR TITLE
Improve texteditor

### DIFF
--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -340,6 +340,10 @@ export default class PPGraph {
     Object.values(this.nodes).forEach((node) => node.drawNodeShape());
   }
 
+  get viewportScaleX(): number {
+    return this.viewport.scale.x;
+  }
+
   get showExecutionVisualisation(): boolean {
     return this._showExecutionVisualisation;
   }
@@ -742,7 +746,7 @@ export default class PPGraph {
       graphSettings: {
         showExecutionVisualisation: this.showExecutionVisualisation,
         viewportCenterPosition: this.viewport.center,
-        viewportScale: this.viewport.scale.x,
+        viewportScale: this.viewportScaleX,
       },
       nodes: nodesSerialized,
       links: linksSerialized,

--- a/src/classes/HybridNode.ts
+++ b/src/classes/HybridNode.ts
@@ -115,13 +115,13 @@ export default abstract class HybridNode extends PPNode {
   }
 
   resizeAndDraw(
-    width: number,
-    height: number,
+    width = this.nodeWidth,
+    height = this.nodeHeight,
     maintainAspectRatio = false
   ): void {
     super.resizeAndDraw(width, height, maintainAspectRatio);
-    this.container.style.width = `${this.nodeWidth}px`;
-    this.container.style.height = `${this.nodeHeight}px`;
+    this.container.style.width = `${width}px`;
+    this.container.style.height = `${height}px`;
   }
 
   _onDoubleClick(event: PIXI.InteractionEvent): void {

--- a/src/classes/HybridNode.ts
+++ b/src/classes/HybridNode.ts
@@ -34,7 +34,7 @@ export default abstract class HybridNode extends PPNode {
     this.container.id = `Container-${this.id}`;
 
     const screenPoint = this.screenPoint();
-    const scaleX = PPGraph.currentGraph.viewport.scale.x;
+    const scaleX = PPGraph.currentGraph.viewportScaleX;
     this.container.classList.add(styles.hybridContainer);
     Object.assign(this.container.style, customStyles);
 

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -504,7 +504,7 @@ export default class PPNode extends PIXI.Container {
     this.onNodeDragOrViewportMove({
       screenX: screenPoint.x,
       screenY: screenPoint.y,
-      scale: PPGraph.currentGraph.viewport.scale.x,
+      scale: PPGraph.currentGraph.viewportScaleX,
     });
   }
 
@@ -1015,7 +1015,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
       this.onNodeDragOrViewportMove({
         screenX: screenPoint.x,
         screenY: screenPoint.y,
-        scale: PPGraph.currentGraph.viewport.scale.x,
+        scale: PPGraph.currentGraph.viewportScaleX,
       });
     }
   }

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -398,8 +398,8 @@ export default class PPNode extends PIXI.Container {
   configure(nodeConfig: SerializedNode): void {
     this.x = nodeConfig.x;
     this.y = nodeConfig.y;
-    this.nodeWidth = nodeConfig.width | this.getMinNodeWidth();
-    this.nodeHeight = nodeConfig.height | this.getMinNodeHeight();
+    this.nodeWidth = nodeConfig.width || this.getMinNodeWidth();
+    this.nodeHeight = nodeConfig.height || this.getMinNodeHeight();
     this.nodeName = nodeConfig.name;
     this.updateBehaviour.setUpdateBehaviour(
       nodeConfig.updateBehaviour.update,

--- a/src/nodes/base.ts
+++ b/src/nodes/base.ts
@@ -41,7 +41,7 @@ export class Placeholder extends PPNode {
 export class Mouse extends PPNode {
   onViewportZoomedHandler: (event?: PIXI.InteractionEvent) => void;
   onViewportZoomed = (event: PIXI.InteractionEvent): void => {
-    const scale = (event as any).viewport.scale.x;
+    const scale = (event as any).viewportScaleX;
     this.setOutputData('scale', scale);
   };
   onViewportMove = (event: PIXI.InteractionEvent): void => {

--- a/src/nodes/text.tsx
+++ b/src/nodes/text.tsx
@@ -143,7 +143,7 @@ export class Label extends PPNode {
         background: 'transparent',
         border: '0 none',
         transformOrigin: 'top left',
-        transform: `scale(${PPGraph.currentGraph.viewport.scale.x}`,
+        transform: `scale(${PPGraph.currentGraph.viewportScaleX}`,
         outline: '0px dashed black',
         left: `${screenPoint.x}px`,
         top: `${screenPoint.y}px`,
@@ -256,7 +256,7 @@ export class Label extends PPNode {
           this.x,
           this.y
         );
-        this.currentInput.style.transform = `scale(${PPGraph.currentGraph.viewport.scale.x}`;
+        this.currentInput.style.transform = `scale(${PPGraph.currentGraph.viewportScaleX}`;
         this.currentInput.style.left = `${screenPoint.x}px`;
         this.currentInput.style.top = `${screenPoint.y}px`;
       }

--- a/src/nodes/textEditor/textEditor.tsx
+++ b/src/nodes/textEditor/textEditor.tsx
@@ -262,7 +262,7 @@ export class TextEditor extends HybridNode {
         []
       );
       const editorRef = useRef(null);
-      const observer = useRef(null);
+      const resizeObserver = useRef(null);
       const [target, setTarget] = useState<Range | undefined>();
       const [index, setIndex] = useState(0);
       const [contentHeight, setContentHeight] = useState(0);
@@ -315,16 +315,16 @@ export class TextEditor extends HybridNode {
       // workaround to get ref of editor to be used as mounted/ready check
       useEffect(() => {
         editorRef.current = ReactEditor.toDOMNode(editor, editor);
-        observer.current = new ResizeObserver((entries) => {
+
+        resizeObserver.current = new ResizeObserver((entries) => {
           for (const entry of entries) {
-            setContentHeight(entry.contentRect.height);
+            setContentHeight(entry.borderBoxSize[0].blockSize);
           }
         });
-
         const target = document.getElementById(this.id);
-        observer.current.observe(target);
+        resizeObserver.current.observe(target);
 
-        return () => observer.current.unobserve(target);
+        return () => resizeObserver.current.unobserve(target);
       }, []);
 
       // wait for editor to be ready before importing/displaying text
@@ -350,26 +350,12 @@ export class TextEditor extends HybridNode {
           } else {
             updateEditorData();
           }
-          setContentHeight(
-            document.getElementById(this.id).getBoundingClientRect().height
-          );
         }
       }, [editorRef.current]);
 
       useEffect(() => {
         if (props.autoHeight) {
-          const editorHeight = Math.ceil(
-            contentHeight * PPGraph.currentGraph.viewportScaleX
-          );
-          console.log(
-            contentHeight,
-            PPGraph.currentGraph.viewportScaleX,
-            editorHeight,
-            props.autoHeight
-          );
-          if (props.autoHeight) {
-            this.resizeAndDraw(this.nodeWidth, contentHeight + 16 * 2);
-          }
+          this.resizeAndDraw(this.nodeWidth, contentHeight);
         }
       }, [contentHeight, props.autoHeight]);
 

--- a/src/nodes/textEditor/textEditor.tsx
+++ b/src/nodes/textEditor/textEditor.tsx
@@ -262,8 +262,10 @@ export class TextEditor extends HybridNode {
         []
       );
       const editorRef = useRef(null);
+      const observer = useRef(null);
       const [target, setTarget] = useState<Range | undefined>();
       const [index, setIndex] = useState(0);
+      const [contentHeight, setContentHeight] = useState(0);
       const [color, setColor] = useState(props.color);
       const renderElement = useCallback(
         (props) => <Element color={color} {...props} />,
@@ -310,19 +312,19 @@ export class TextEditor extends HybridNode {
         setTarget(null);
       };
 
-      const setNewHeight = () => {
-        if (props.autoHeight) {
-          const editorHeight = Math.ceil(
-            document.getElementById(this.id).getBoundingClientRect().height /
-              PPGraph.currentGraph.viewport.scale.x
-          );
-          this.resizeAndDraw(this.nodeWidth, editorHeight);
-        }
-      };
-
       // workaround to get ref of editor to be used as mounted/ready check
       useEffect(() => {
         editorRef.current = ReactEditor.toDOMNode(editor, editor);
+        observer.current = new ResizeObserver((entries) => {
+          for (const entry of entries) {
+            setContentHeight(entry.contentRect.height);
+          }
+        });
+
+        const target = document.getElementById(this.id);
+        observer.current.observe(target);
+
+        return () => observer.current.unobserve(target);
       }, []);
 
       // wait for editor to be ready before importing/displaying text
@@ -348,20 +350,28 @@ export class TextEditor extends HybridNode {
           } else {
             updateEditorData();
           }
-
-          // delay getting div size as
-          // the css takes a little before it is applied
-          setTimeout(() => {
-            setNewHeight();
-          }, 200);
+          setContentHeight(
+            document.getElementById(this.id).getBoundingClientRect().height
+          );
         }
       }, [editorRef.current]);
 
       useEffect(() => {
         if (props.autoHeight) {
-          setNewHeight();
+          const editorHeight = Math.ceil(
+            contentHeight * PPGraph.currentGraph.viewportScaleX
+          );
+          console.log(
+            contentHeight,
+            PPGraph.currentGraph.viewportScaleX,
+            editorHeight,
+            props.autoHeight
+          );
+          if (props.autoHeight) {
+            this.resizeAndDraw(this.nodeWidth, contentHeight + 16 * 2);
+          }
         }
-      }, [props.autoHeight]);
+      }, [contentHeight, props.autoHeight]);
 
       useEffect(() => {
         if (props.doubleClicked) {
@@ -401,7 +411,6 @@ export class TextEditor extends HybridNode {
           }
         }
         setTarget(null);
-        setNewHeight();
 
         // update in and outputs
         this.setInputData(textJSONSocketName, value);

--- a/src/nodes/widgets/widgetNodes.tsx
+++ b/src/nodes/widgets/widgetNodes.tsx
@@ -123,10 +123,10 @@ export class WidgetButton extends HybridNode {
 
     this.onNodeResize = () => {
       this.container.style.width = `${
-        this.nodeWidth - (2 * margin) / PPGraph.currentGraph.viewport.scale.x
+        this.nodeWidth - (2 * margin) / PPGraph.currentGraph.viewportScaleX
       }px`;
       this.container.style.height = `${
-        this.nodeHeight - (2 * margin) / PPGraph.currentGraph.viewport.scale.x
+        this.nodeHeight - (2 * margin) / PPGraph.currentGraph.viewportScaleX
       }px`;
       this.update();
     };
@@ -169,7 +169,7 @@ export class WidgetButton extends HybridNode {
               border: 0,
               height: `${
                 this.nodeHeight -
-                (2 * margin) / PPGraph.currentGraph.viewport.scale.x
+                (2 * margin) / PPGraph.currentGraph.viewportScaleX
               }px`,
               boxShadow: 16,
               '&:hover': {
@@ -188,11 +188,11 @@ export class WidgetButton extends HybridNode {
                 border: 0,
                 width: `${
                   this.nodeWidth -
-                  (8 * margin) / PPGraph.currentGraph.viewport.scale.x
+                  (8 * margin) / PPGraph.currentGraph.viewportScaleX
                 }px`,
                 height: `${
                   this.nodeHeight -
-                  (8 * margin) / PPGraph.currentGraph.viewport.scale.x
+                  (8 * margin) / PPGraph.currentGraph.viewportScaleX
                 }px`,
                 borderRadius: `${this.nodeWidth / 16}px`,
                 boxShadow: 16,
@@ -292,10 +292,10 @@ export class WidgetSwitch extends HybridNode {
 
     this.onNodeResize = () => {
       this.container.style.width = `${
-        this.nodeWidth - (2 * margin) / PPGraph.currentGraph.viewport.scale.x
+        this.nodeWidth - (2 * margin) / PPGraph.currentGraph.viewportScaleX
       }px`;
       this.container.style.height = `${
-        this.nodeHeight - (2 * margin) / PPGraph.currentGraph.viewport.scale.x
+        this.nodeHeight - (2 * margin) / PPGraph.currentGraph.viewportScaleX
       }px`;
       this.update();
     };
@@ -331,7 +331,7 @@ export class WidgetSwitch extends HybridNode {
               border: 0,
               height: `${
                 this.nodeHeight -
-                (2 * margin) / PPGraph.currentGraph.viewport.scale.x
+                (2 * margin) / PPGraph.currentGraph.viewportScaleX
               }px`,
               boxShadow: 16,
               '&:hover': {
@@ -461,10 +461,10 @@ export class WidgetSlider extends HybridNode {
 
     this.onNodeResize = () => {
       this.container.style.width = `${
-        this.nodeWidth - (2 * margin) / PPGraph.currentGraph.viewport.scale.x
+        this.nodeWidth - (2 * margin) / PPGraph.currentGraph.viewportScaleX
       }px`;
       this.container.style.height = `${
-        this.nodeHeight - (2 * margin) / PPGraph.currentGraph.viewport.scale.x
+        this.nodeHeight - (2 * margin) / PPGraph.currentGraph.viewportScaleX
       }px`;
       this.update();
     };
@@ -521,7 +521,7 @@ export class WidgetSlider extends HybridNode {
               border: 0,
               height: `${
                 this.nodeHeight -
-                (2 * margin) / PPGraph.currentGraph.viewport.scale.x
+                (2 * margin) / PPGraph.currentGraph.viewportScaleX
               }px`,
               boxShadow: 16,
               '&:hover': {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -536,7 +536,7 @@ export const ensureVisible = (nodes: PPNode[]): void => {
     boundsToZoomTo.width,
     boundsToZoomTo.height
   );
-  const fitScaleWithViewport = fitScale / currentGraph.viewport.scale.x;
+  const fitScaleWithViewport = fitScale / currentGraph.viewportScaleX;
 
   currentGraph.viewport.animate({
     position: new PIXI.Point(


### PR DESCRIPTION
* Rewritten how the vertical resizing of the textEditor node is handled. I am now using a resizeObserver to listen to size changes. That works a lot better and does not require timeouts anymore
* Fixed an issue of hybrid node sizes not being correct
* added a getter for the viewport scale