### PR TITLE
add back create custom node

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -262,6 +262,14 @@ export const filterOptionsNode = (
       keys: ['name', 'title', 'description'],
       threshold: matchSorter.rankings.ACRONYM,
     });
+    sorted.push({
+      title: inputValue,
+      key: inputValue,
+      name: inputValue,
+      description: '',
+      hasInputs: true,
+      isNew: true,
+    });
   }
   setNodeSearchCount(sorted.length);
   return sorted;


### PR DESCRIPTION
I had accidentally removed the ability add custom nodes via typing a new node name.

<img width="423" alt="Screenshot 2022-11-13 at 13 46 25" src="https://user-images.githubusercontent.com/4619772/201522403-f72d3946-0f22-45c8-8818-30822c2075ac.png">
