### PR TITLE
made node browser not appear if old link had input

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -752,8 +752,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
       // wait before clearing clickedSocketRef
       // so handleNodeItemSelect has access
       setTimeout(() => {
-        currentGraph.current.clearTempConnection();
-        currentGraph.current.overrideNodeCursorPosition = null;
+        currentGraph.current.stopConnecting();
       }, 100);
     }
   }, [isNodeSearchVisible]);


### PR DESCRIPTION
This has been annoying me for some time, when you disconnect a link by dragging output first, it pops up browser, made it only happen if there is no input from before