### PR TITLE
Iframe node

### DIFF
--- a/src/nodes/draw/html.tsx
+++ b/src/nodes/draw/html.tsx
@@ -150,7 +150,7 @@ export class HtmlRenderer extends HybridNode {
           <Box
             style={{
               position: 'relative',
-              height: '100vh',
+              height: 'calc(100vh - 16px)',
             }}
             dangerouslySetInnerHTML={{ __html: htmlData }}
           />
@@ -164,14 +164,44 @@ export class HtmlRenderer extends HybridNode {
           ref={iframeRef}
           style={{
             width: '100%',
-            height: 'calc(100% - 8px)',
+            height: '100%',
             borderWidth: 0,
           }}
-          initialContent="<!DOCTYPE html><html><head></head><body><div></div></body></html>"
+          initialContent="<!DOCTYPE html><html><head></head><body style='overflow:hidden;'><div></div></body></html>"
         >
           <MyComponent />
         </Frame>
       </ErrorBoundary>
     );
   };
+}
+
+export class EmbedWebsite extends HtmlRenderer {
+  public getName(): string {
+    return 'Embed a website';
+  }
+
+  public getDescription(): string {
+    return 'Embed a website using an iframe';
+  }
+
+  public getDefaultNodeWidth(): number {
+    return 800;
+  }
+
+  public getDefaultNodeHeight(): number {
+    return 400;
+  }
+
+  protected getDefaultIO(): PPSocket[] {
+    return [
+      new PPSocket(
+        SOCKET_TYPE.IN,
+        inputSocketName,
+        new CodeType(),
+        `<iframe src="https://www.tldraw.com/"  width="100%" height="100%" style="width: 100%; height: 100%; border-width: 0px;"></iframe>`,
+        false
+      ),
+    ];
+  }
 }

--- a/src/nodes/draw/html.tsx
+++ b/src/nodes/draw/html.tsx
@@ -167,7 +167,7 @@ export class HtmlRenderer extends HybridNode {
             height: '100%',
             borderWidth: 0,
           }}
-          initialContent="<!DOCTYPE html><html><head></head><body style='overflow:hidden;'><div></div></body></html>"
+          initialContent="<!DOCTYPE html><html><head><style>* {border: none;}</style></head><body style='overflow:hidden; border-width: 0px;'><div></div></body></html>"
         >
           <MyComponent />
         </Frame>
@@ -182,7 +182,7 @@ export class EmbedWebsite extends HtmlRenderer {
   }
 
   public getDescription(): string {
-    return 'Embed a website using an iframe';
+    return 'Embed a website using an iframe (based on HtmlRenderer)';
   }
 
   public getDefaultNodeWidth(): number {
@@ -199,7 +199,7 @@ export class EmbedWebsite extends HtmlRenderer {
         SOCKET_TYPE.IN,
         inputSocketName,
         new CodeType(),
-        `<iframe src="https://www.tldraw.com/"  width="100%" height="100%" style="width: 100%; height: 100%; border-width: 0px;"></iframe>`,
+        `<iframe src="https://en.wikipedia.org/wiki/Special:Random" style="width: 100%; height: 100%;"></iframe>`,
         false
       ),
     ];


### PR DESCRIPTION
Added a node to embed websites. It essentially is an html node, but has just a simple iframe code in there. This should make it a tidbit easier for users who do not know much about iframes and how to use them.  It can still be made easier so you only need to write a URL and don't see any iframe code, but for now I believe it is ok.
It loads a random wikipedia article by default.

<img width="1022" alt="Screen Shot 2022-12-20 at 21 19 30" src="https://user-images.githubusercontent.com/4619772/208758949-d069e77f-b2b1-412f-beb4-12ac1b692cd9.png">
