### PR TITLE
Improve inspector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1074,6 +1074,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
               currentGraph={PPGraph.currentGraph}
               openNodeSearch={openNodeSearch}
               zoomToFitSelection={zoomToFitNodes}
+              setShowLeftSideDrawer={setShowLeftSideDrawer}
             />
           )}
           {isSocketContextMenuOpen && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,7 @@ const App = (): JSX.Element => {
   const nodeSearchInput = useRef<HTMLInputElement | null>(null);
   const [isGraphSearchOpen, setIsGraphSearchOpen] = useState(false);
   const [isNodeSearchVisible, setIsNodeSearchVisible] = useState(false);
+  const [showLeftSideDrawer, setShowLeftSideDrawer] = useState(false);
   const [nodeSearchCount, setNodeSearchCount] = useState(0);
   const [isGraphContextMenuOpen, setIsGraphContextMenuOpen] = useState(false);
   const [isNodeContextMenuOpen, setIsNodeContextMenuOpen] = useState(false);
@@ -567,6 +568,10 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
               break;
             case 'e':
               setShowEdit((prevState) => !prevState);
+              e.preventDefault();
+              break;
+            case '\\':
+              setShowLeftSideDrawer((prevState) => !prevState);
               e.preventDefault();
               break;
             case 'z':
@@ -1054,6 +1059,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
               contextMenuPosition={contextMenuPosition}
               setIsGraphSearchOpen={setIsGraphSearchOpen}
               openNodeSearch={openNodeSearch}
+              setShowLeftSideDrawer={setShowLeftSideDrawer}
               setShowEdit={setShowEdit}
               uploadGraph={uploadGraph}
               showComments={showComments}
@@ -1080,6 +1086,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
           )}
           <PixiContainer ref={pixiContext} />
           <GraphOverlay
+            toggle={showLeftSideDrawer}
             currentGraph={PPGraph.currentGraph}
             randomMainColor={RANDOMMAINCOLOR}
           />

--- a/src/InspectorContainer.tsx
+++ b/src/InspectorContainer.tsx
@@ -1,37 +1,16 @@
 import React from 'react';
-import {
-  Box,
-  Icon,
-  Stack,
-  ThemeProvider,
-  ToggleButton,
-  ToggleButtonGroup,
-} from '@mui/material';
+import { Box, Stack, ThemeProvider } from '@mui/material';
 import styles from './utils/style.module.css';
 import PPNode from './classes/NodeClass';
 import { PropertyArrayContainer } from './PropertyArrayContainer';
-import {
-  DRAWER30_ICON,
-  DRAWER60_ICON,
-  DRAWER90_ICON,
-  customTheme,
-} from './utils/constants';
+import { customTheme } from './utils/constants';
 
 type MyProps = {
   selectedNode: PPNode;
   randomMainColor: string;
-  widthPercentage: number;
-  setWidthPercentage: (value: number | ((prevVar: number) => number)) => void;
 };
 
 const InspectorContainer: React.FunctionComponent<MyProps> = (props) => {
-  const handleWidthPercentage = (
-    event: React.MouseEvent<HTMLElement>,
-    newPercentage: number | null
-  ) => {
-    props.setWidthPercentage(newPercentage);
-  };
-
   return (
     <ThemeProvider theme={customTheme}>
       <Stack
@@ -65,33 +44,6 @@ const InspectorContainer: React.FunctionComponent<MyProps> = (props) => {
           >
             {props.selectedNode?.name}
           </Box>
-          <ToggleButtonGroup
-            value={props.widthPercentage}
-            exclusive
-            onChange={handleWidthPercentage}
-            size="small"
-            sx={{
-              '& .MuiToggleButtonGroup-grouped': {
-                border: 0,
-              },
-            }}
-          >
-            <ToggleButton value="0.9">
-              <Icon classes={{ root: styles.iconRoot }}>
-                <img className={styles.imageIcon} src={DRAWER90_ICON} />
-              </Icon>
-            </ToggleButton>
-            <ToggleButton value="0.6">
-              <Icon classes={{ root: styles.iconRoot }}>
-                <img className={styles.imageIcon} src={DRAWER60_ICON} />
-              </Icon>
-            </ToggleButton>
-            <ToggleButton value="0.3">
-              <Icon classes={{ root: styles.iconRoot }}>
-                <img className={styles.imageIcon} src={DRAWER30_ICON} />
-              </Icon>
-            </ToggleButton>
-          </ToggleButtonGroup>
         </Box>
         <PropertyArrayContainer
           selectedNode={props.selectedNode}

--- a/src/components/ContextMenus.tsx
+++ b/src/components/ContextMenus.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import { createStyles, makeStyles } from '@mui/styles';
 import SearchIcon from '@mui/icons-material/Search';
+import TuneIcon from '@mui/icons-material/Tune';
 import UploadIcon from '@mui/icons-material/Upload';
 import EditIcon from '@mui/icons-material/Edit';
 import SaveIcon from '@mui/icons-material/Save';
@@ -214,6 +215,19 @@ export const GraphContextMenu = (props) => {
           <ListItemText>Find node</ListItemText>
           <Typography variant="body2" color="text.secondary">
             {`${props.controlOrMetaKey}+F`}
+          </Typography>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            props.setShowLeftSideDrawer();
+          }}
+        >
+          <ListItemIcon>
+            <TuneIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Toggle node inspector</ListItemText>
+          <Typography variant="body2" color="text.secondary">
+            {`${props.controlOrMetaKey}+\\`}
           </Typography>
         </MenuItem>
         <Divider />

--- a/src/components/ContextMenus.tsx
+++ b/src/components/ContextMenus.tsx
@@ -377,6 +377,19 @@ export const NodeContextMenu = (props) => {
             Shift+2
           </Typography>
         </MenuItem>
+        <MenuItem
+          onClick={() => {
+            props.setShowLeftSideDrawer();
+          }}
+        >
+          <ListItemIcon>
+            <TuneIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Toggle node inspector</ListItemText>
+          <Typography variant="body2" color="text.secondary">
+            {`${props.controlOrMetaKey}+\\`}
+          </Typography>
+        </MenuItem>
         <Divider />
         <MenuItem
           onClick={() => {

--- a/src/components/GraphOverlay.tsx
+++ b/src/components/GraphOverlay.tsx
@@ -9,6 +9,7 @@ import GraphOverlaySocketInspector from './GraphOverlaySocketInspector';
 type GraphOverlayProps = {
   currentGraph: PPGraph;
   randomMainColor: string;
+  toggle: boolean;
 };
 
 const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
@@ -49,9 +50,11 @@ const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
       ids.forEach((id) => InterfaceController.removeListener(id));
     };
   });
+
   return (
     <>
       <GraphOverlayDrawer
+        toggle={props.toggle}
         selectedNodes={selectedNodes}
         randomMainColor={props.randomMainColor}
       />

--- a/src/components/GraphOverlayDrawer.tsx
+++ b/src/components/GraphOverlayDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Box } from '@mui/material';
 import PPNode from '../classes/NodeClass';
 import ResponsiveDrawer from './ResponsiveDrawer';
@@ -6,6 +6,7 @@ import ResponsiveDrawer from './ResponsiveDrawer';
 type GraphOverlayDrawerProps = {
   randomMainColor: string;
   selectedNodes: PPNode[];
+  toggle: boolean;
 };
 
 const GraphOverlayDrawer: React.FunctionComponent<GraphOverlayDrawerProps> = (
@@ -13,13 +14,12 @@ const GraphOverlayDrawer: React.FunctionComponent<GraphOverlayDrawerProps> = (
 ) => {
   // drawer
   const defaultDrawerWidth = 320;
-  const [drawerWidth, setDrawerWidth] = useState(defaultDrawerWidth);
 
   return (
     <Box sx={{ position: 'relative' }}>
       <ResponsiveDrawer
-        drawerWidth={drawerWidth}
-        setDrawerWidth={setDrawerWidth}
+        drawerWidth={defaultDrawerWidth}
+        toggle={props.toggle}
         selectedNode={
           props.selectedNodes.length > 0 ? props.selectedNodes[0] : null
         }

--- a/src/components/GraphOverlayDrawer.tsx
+++ b/src/components/GraphOverlayDrawer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Box } from '@mui/material';
 import PPNode from '../classes/NodeClass';
 import ResponsiveDrawer from './ResponsiveDrawer';
@@ -14,11 +14,13 @@ const GraphOverlayDrawer: React.FunctionComponent<GraphOverlayDrawerProps> = (
 ) => {
   // drawer
   const defaultDrawerWidth = 320;
+  const [drawerWidth, setDrawerWidth] = useState(defaultDrawerWidth);
 
   return (
     <Box sx={{ position: 'relative' }}>
       <ResponsiveDrawer
-        drawerWidth={defaultDrawerWidth}
+        drawerWidth={drawerWidth}
+        setDrawerWidth={setDrawerWidth}
         toggle={props.toggle}
         selectedNode={
           props.selectedNodes.length > 0 ? props.selectedNodes[0] : null

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -45,7 +45,7 @@ const ResponsiveDrawer = (props) => {
     return (
       <Box>
         <Button
-          title="Toggle Inspector"
+          title={`${props.posLeft ? 'Close inspector' : 'Open inspector'}`}
           size="small"
           onClick={handleDrawerToggle}
           color="primary"
@@ -58,12 +58,16 @@ const ResponsiveDrawer = (props) => {
             minWidth: '32px',
             background: `${
               props.selectedNode
-                ? Color(props.randomMainColor).alpha(0.4)
+                ? Color(props.randomMainColor).alpha(0.2)
                 : 'unset'
             }`,
           }}
         >
-          {props.posLeft ? <ChevronRightIcon /> : <TuneIcon />}
+          {props.posLeft ? (
+            <ChevronRightIcon />
+          ) : (
+            props.selectedNode && <TuneIcon />
+          )}
         </Button>
       </Box>
     );

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -1,15 +1,20 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { Drawer } from '@mui/material';
+import { Box, Button, Drawer, Paper, Stack } from '@mui/material';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import TuneIcon from '@mui/icons-material/Tune';
 import Color from 'color';
 import InspectorContainer from '../InspectorContainer';
+import { COLOR_DARK, COLOR_WHITE_TEXT } from '../utils/constants';
 import styles from '../utils/style.module.css';
 
 const ResponsiveDrawer = (props) => {
   // leaving this commented here for potential future testing
   //console.log('redrawing responsivedrawer');
-  const [widthPercentage, setWidthPercentage] = useState(
-    props.drawerWidth / window.innerWidth
-  );
+  const [open, setOpen] = useState(true);
+
+  const handleDrawerToggle = () => {
+    setOpen((prevState) => !prevState);
+  };
 
   const handleMouseDown = (e) => {
     document.addEventListener('mouseup', handleMouseUp, true);
@@ -33,40 +38,94 @@ const ResponsiveDrawer = (props) => {
   }, []);
 
   useEffect(() => {
-    props.setDrawerWidth(window.innerWidth * widthPercentage);
-  }, [widthPercentage]);
+    handleDrawerToggle();
+  }, [props.toggle]);
+
+  function DrawerToggle(props) {
+    return (
+      <Box>
+        <Button
+          title="Toggle Inspector"
+          size="small"
+          onClick={handleDrawerToggle}
+          color="primary"
+          sx={{
+            position: 'absolute',
+            top: '40px',
+            left: `${props.posLeft ? '-32px' : 'auto'}`,
+            right: `${props.posLeft ? 'auto' : '32px'}`,
+            width: '32px',
+            minWidth: '32px',
+            background: `${
+              props.selectedNode
+                ? Color(props.randomMainColor).alpha(0.4)
+                : 'unset'
+            }`,
+          }}
+        >
+          {props.posLeft ? <ChevronRightIcon /> : <TuneIcon />}
+        </Button>
+      </Box>
+    );
+  }
 
   return (
-    <Drawer
-      anchor="right"
-      variant="persistent"
-      hideBackdrop
-      open={props.selectedNode !== null}
-      ModalProps={{
-        keepMounted: true,
-      }}
-      PaperProps={{
-        elevation: 8,
-        style: {
-          width: props.drawerWidth,
-          border: 0,
-          background: `${Color(props.randomMainColor).alpha(0.8)}`,
-        },
-      }}
-    >
-      <div
-        onMouseDown={(e) => handleMouseDown(e)}
-        className={styles.dragger}
-      ></div>
-      {props.selectedNode && (
-        <InspectorContainer
+    <>
+      {!open && (
+        <DrawerToggle
           selectedNode={props.selectedNode}
           randomMainColor={props.randomMainColor}
-          widthPercentage={widthPercentage}
-          setWidthPercentage={setWidthPercentage}
         />
       )}
-    </Drawer>
+      <Drawer
+        anchor="right"
+        variant="persistent"
+        hideBackdrop
+        open={open}
+        ModalProps={{
+          keepMounted: true,
+        }}
+        PaperProps={{
+          elevation: 8,
+          style: {
+            width: props.drawerWidth,
+            border: 0,
+            background: `${Color(props.randomMainColor).alpha(0.8)}`,
+            overflowY: 'visible',
+          },
+        }}
+      >
+        <div
+          onMouseDown={(e) => handleMouseDown(e)}
+          className={styles.dragger}
+        ></div>
+        <DrawerToggle posLeft={true} randomMainColor={props.randomMainColor} />
+        {props.selectedNode ? (
+          <InspectorContainer
+            selectedNode={props.selectedNode}
+            randomMainColor={props.randomMainColor}
+          />
+        ) : (
+          <Paper
+            component={Stack}
+            direction="column"
+            justifyContent="center"
+            sx={{ height: '100%', background: 'unset' }}
+          >
+            <Box
+              sx={{
+                textAlign: 'center',
+                color: Color(props.randomMainColor).isDark()
+                  ? COLOR_WHITE_TEXT
+                  : COLOR_DARK,
+              }}
+            >
+              No node selected
+            </Box>
+          </Paper>
+        )}
+      </Drawer>
+    </>
   );
 };
 
@@ -74,6 +133,7 @@ const ResponsiveDrawer = (props) => {
 export default React.memo(ResponsiveDrawer, (prevProps, newProps) => {
   return (
     prevProps.selectedNode?.id === newProps.selectedNode?.id &&
-    prevProps.drawerWidth === newProps.drawerWidth
+    prevProps.drawerWidth === newProps.drawerWidth &&
+    prevProps.toggle === newProps.toggle
   );
 });

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -7,6 +7,38 @@ import InspectorContainer from '../InspectorContainer';
 import { COLOR_DARK, COLOR_WHITE_TEXT } from '../utils/constants';
 import styles from '../utils/style.module.css';
 
+function DrawerToggle(props) {
+  return (
+    <Box>
+      <Button
+        title={`${props.posLeft ? 'Close inspector' : 'Open inspector'}`}
+        size="small"
+        onClick={props.handleDrawerToggle}
+        color="primary"
+        sx={{
+          position: 'absolute',
+          top: '40px',
+          left: `${props.posLeft ? '-32px' : 'auto'}`,
+          right: `${props.posLeft ? 'auto' : '32px'}`,
+          width: '32px',
+          minWidth: '32px',
+          background: `${
+            props.selectedNode
+              ? Color(props.randomMainColor).alpha(0.2)
+              : 'unset'
+          }`,
+        }}
+      >
+        {props.posLeft ? (
+          <ChevronRightIcon />
+        ) : (
+          props.selectedNode && <TuneIcon />
+        )}
+      </Button>
+    </Box>
+  );
+}
+
 const ResponsiveDrawer = (props) => {
   // leaving this commented here for potential future testing
   const [open, setOpen] = useState(true);
@@ -40,44 +72,13 @@ const ResponsiveDrawer = (props) => {
     handleDrawerToggle();
   }, [props.toggle]);
 
-  function DrawerToggle(props) {
-    return (
-      <Box>
-        <Button
-          title={`${props.posLeft ? 'Close inspector' : 'Open inspector'}`}
-          size="small"
-          onClick={handleDrawerToggle}
-          color="primary"
-          sx={{
-            position: 'absolute',
-            top: '40px',
-            left: `${props.posLeft ? '-32px' : 'auto'}`,
-            right: `${props.posLeft ? 'auto' : '32px'}`,
-            width: '32px',
-            minWidth: '32px',
-            background: `${
-              props.selectedNode
-                ? Color(props.randomMainColor).alpha(0.2)
-                : 'unset'
-            }`,
-          }}
-        >
-          {props.posLeft ? (
-            <ChevronRightIcon />
-          ) : (
-            props.selectedNode && <TuneIcon />
-          )}
-        </Button>
-      </Box>
-    );
-  }
-
   return (
     <>
       {!open && (
         <DrawerToggle
           selectedNode={props.selectedNode}
           randomMainColor={props.randomMainColor}
+          handleDrawerToggle={handleDrawerToggle}
         />
       )}
       <Drawer
@@ -102,7 +103,11 @@ const ResponsiveDrawer = (props) => {
           onMouseDown={(e) => handleMouseDown(e)}
           className={styles.dragger}
         ></div>
-        <DrawerToggle posLeft={true} randomMainColor={props.randomMainColor} />
+        <DrawerToggle
+          posLeft={true}
+          randomMainColor={props.randomMainColor}
+          handleDrawerToggle={handleDrawerToggle}
+        />
         {props.selectedNode ? (
           <InspectorContainer
             selectedNode={props.selectedNode}

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -9,7 +9,6 @@ import styles from '../utils/style.module.css';
 
 const ResponsiveDrawer = (props) => {
   // leaving this commented here for potential future testing
-  //console.log('redrawing responsivedrawer');
   const [open, setOpen] = useState(true);
 
   const handleDrawerToggle = () => {


### PR DESCRIPTION
This is the first step of some improvements regarding the inspector
* the right side drawer can now be toggled
  * using an icon in the top right (visible if a node is selected)
  * using a keyboard shortcut ctrl+\
  * using toggle entries in the graph and node menus

<img width="653" alt="Screenshot 2023-01-11 at 21 21 39" src="https://user-images.githubusercontent.com/4619772/211910444-550c2e3b-c2d1-4c20-bf36-cf0c754cf944.png">
<img width="653" alt="Screenshot 2023-01-11 at 21 22 01" src="https://user-images.githubusercontent.com/4619772/211910449-435bc209-8ad7-4832-99a4-9dc39890ccb1.png">
<img width="311" alt="Screenshot 2023-01-11 at 21 25 10" src="https://user-images.githubusercontent.com/4619772/211910452-4fa08681-04cf-4b68-97b2-f4d6a29232c2.png">
<img width="306" alt="Screenshot 2023-01-11 at 21 25 21" src="https://user-images.githubusercontent.com/4619772/211910455-c9b93865-3752-47fd-9553-039a04f64043.png">
