### PR TITLE
Remove loadURL parameter after loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ import {
   getNodeDataFromText,
   isEventComingFromWithinTextInput,
   removeExtension,
+  removeUrlParameter,
   roundNumber,
   useStateRef,
   writeDataToClipboard,
@@ -526,6 +527,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     console.log('loadURL: ', loadURL, 'new', createEmptyGraph);
     if (loadURL) {
       PPStorage.getInstance().loadGraphFromURL(loadURL);
+      removeUrlParameter('loadURL');
     } else {
       if (!createEmptyGraph) {
         PPStorage.getInstance().loadGraph();

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -663,3 +663,16 @@ export function sortCompare(a: string, b: string, desc: boolean): number {
     sensitivity: 'base',
   });
 }
+
+export function removeUrlParameter(parameter: string): void {
+  // Get the current URL
+  const currentUrl = new URL(window.location.href);
+  const searchParams = new URLSearchParams(currentUrl.search);
+
+  // Remove the specified parameter
+  searchParams.delete(parameter);
+
+  // Update the URL
+  currentUrl.search = searchParams.toString();
+  window.history.pushState({}, '', currentUrl.href);
+}


### PR DESCRIPTION
I kept running into the following issue
* I loaded a graph via the loadURL parameter
* I made a change and saved it as a new graph
* for whatever reason I had to reload the page
* now, due to the loadURL parameter, the old graph gets loaded and not what I was expecting the one I was working on in the meantime

This PR suggests to remove the parameter right after it has been loaded. The browser history is kept so one can go back to it.