### PR TITLE
Socket click to focus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -616,8 +616,8 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     ids.push(
       InterfaceController.addListener(
         ListenEvent.OpenInspectorFocusingOnSocket,
-        () => {
-          setShowRightSideDrawer(true);
+        (socket: PPSocket) => {
+          setShowRightSideDrawer(socket !== null);
         }
       )
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,7 +118,7 @@ const App = (): JSX.Element => {
   const nodeSearchInput = useRef<HTMLInputElement | null>(null);
   const [isGraphSearchOpen, setIsGraphSearchOpen] = useState(false);
   const [isNodeSearchVisible, setIsNodeSearchVisible] = useState(false);
-  const [showLeftSideDrawer, setShowLeftSideDrawer] = useState(false);
+  const [showRightSideDrawer, setShowRightSideDrawer] = useState(false);
   const [nodeSearchCount, setNodeSearchCount] = useState(0);
   const [isGraphContextMenuOpen, setIsGraphContextMenuOpen] = useState(false);
   const [isNodeContextMenuOpen, setIsNodeContextMenuOpen] = useState(false);
@@ -523,7 +523,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
               e.preventDefault();
               break;
             case '\\':
-              setShowLeftSideDrawer((prevState) => !prevState);
+              setShowRightSideDrawer((prevState) => !prevState);
               e.preventDefault();
               break;
             case 'z':
@@ -613,6 +613,14 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
         setGraphSearchActiveItem(data);
       })
     );
+    ids.push(
+      InterfaceController.addListener(
+        ListenEvent.OpenInspectorFocusingOnSocket,
+        () => {
+          setShowRightSideDrawer(true);
+        }
+      )
+    );
 
     InterfaceController.onOpenNodeSearch = openNodeSearch;
 
@@ -668,7 +676,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     return () => {
       ids.forEach((id) => InterfaceController.removeListener(id));
     };
-  });
+  }, []);
 
   // addEventListener to graphSearchInput
   useEffect(() => {
@@ -1021,7 +1029,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
               contextMenuPosition={contextMenuPosition}
               setIsGraphSearchOpen={setIsGraphSearchOpen}
               openNodeSearch={openNodeSearch}
-              setShowLeftSideDrawer={setShowLeftSideDrawer}
+              setShowRightSideDrawer={setShowRightSideDrawer}
               setShowEdit={setShowEdit}
               uploadGraph={uploadGraph}
               showComments={showComments}
@@ -1036,7 +1044,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
               currentGraph={PPGraph.currentGraph}
               openNodeSearch={openNodeSearch}
               zoomToFitSelection={zoomToFitNodes}
-              setShowLeftSideDrawer={setShowLeftSideDrawer}
+              setShowRightSideDrawer={setShowRightSideDrawer}
             />
           )}
           {isSocketContextMenuOpen && (
@@ -1049,7 +1057,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
           )}
           <PixiContainer ref={pixiContext} />
           <GraphOverlay
-            toggle={showLeftSideDrawer}
+            toggle={showRightSideDrawer}
             currentGraph={PPGraph.currentGraph}
             randomMainColor={RANDOMMAINCOLOR}
           />

--- a/src/InspectorContainer.tsx
+++ b/src/InspectorContainer.tsx
@@ -11,6 +11,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import Color from 'color';
 import styles from './utils/style.module.css';
 import PPNode from './classes/NodeClass';
+import Socket from './classes/SocketClass';
 import { PropertyArrayContainer } from './PropertyArrayContainer';
 import { COLOR_WHITE_TEXT, COLOR_DARK, customTheme } from './utils/constants';
 
@@ -136,6 +137,7 @@ function InspectorHeader(props) {
 
 type InspectorContainerProps = {
   selectedNodes: PPNode[];
+  socketToInspect: Socket;
   randomMainColor: string;
   filter: string;
   setFilter: React.Dispatch<React.SetStateAction<string>>;
@@ -179,6 +181,7 @@ const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
         )}
         <PropertyArrayContainer
           selectedNodes={props.selectedNodes}
+          socketToInspect={props.socketToInspect}
           randomMainColor={props.randomMainColor}
           filter={props.filter}
           setFilter={props.setFilter}

--- a/src/InterfaceController.ts
+++ b/src/InterfaceController.ts
@@ -13,6 +13,7 @@ export enum ListenEvent {
   GlobalPointerDown, // data = void TODO implement
   GlobalPointerUp, // data = event: PIXI.InteractionEvent
   GraphChanged, // data = {id,name}
+  OpenInspectorFocusingOnSocket, // (data: Socket) => void: called when inspector should be opened to focus on a socket
 }
 
 export default class InterfaceController {
@@ -24,6 +25,7 @@ export default class InterfaceController {
     4: {},
     5: {},
     6: {},
+    7: {},
   }; // not sure why this one is so messed up and needs these defined by default, very annoying
 
   // we use this listener structure here as there can be multiple listeners, not needed for everything (sometimes there is just one listener)
@@ -69,6 +71,5 @@ export default class InterfaceController {
   static onOpenSocketInspector: (pos: PIXI.Point, data: Socket) => void =
     () => {}; // called when socket inspector should be opened
   static onCloseSocketInspector: () => void; // called when socket inspector should be closed
-  static onOpenInspectorFocusingOnSocket: (data: Socket) => void = () => {}; // called when inspector should be opened to focus on a socket
   static selectionRedrawn: (pos: PIXI.Point) => void = () => {};
 }

--- a/src/InterfaceController.ts
+++ b/src/InterfaceController.ts
@@ -23,7 +23,7 @@ export default class InterfaceController {
     3: {},
     4: {},
     5: {},
-    6: {}
+    6: {},
   }; // not sure why this one is so messed up and needs these defined by default, very annoying
 
   // we use this listener structure here as there can be multiple listeners, not needed for everything (sometimes there is just one listener)
@@ -58,16 +58,17 @@ export default class InterfaceController {
   static showSnackBar: (
     message: SnackbarMessage,
     options?: OptionsObject
-  ) => void = () => { };
-  static hideSnackBar = (key: SnackbarKey) => { };
+  ) => void = () => {};
+  static hideSnackBar = (key: SnackbarKey) => {};
 
   static onRightClick: (
     event: PIXI.InteractionEvent,
     target: PIXI.DisplayObject
-  ) => void = () => { }; // called when the graph is right clicked
-  static onOpenNodeSearch: (pos: PIXI.Point) => void = () => { }; // called node search should be openend
+  ) => void = () => {}; // called when the graph is right clicked
+  static onOpenNodeSearch: (pos: PIXI.Point) => void = () => {}; // called node search should be openend
   static onOpenSocketInspector: (pos: PIXI.Point, data: Socket) => void =
-    () => { }; // called when socket inspector should be opened
+    () => {}; // called when socket inspector should be opened
   static onCloseSocketInspector: () => void; // called when socket inspector should be closed
-  static selectionRedrawn: (pos: PIXI.Point) => void = () => { };
+  static onOpenInspectorFocusingOnSocket: (data: Socket) => void = () => {}; // called when inspector should be opened to focus on a socket
+  static selectionRedrawn: (pos: PIXI.Point) => void = () => {};
 }

--- a/src/PropertyArrayContainer.tsx
+++ b/src/PropertyArrayContainer.tsx
@@ -169,6 +169,7 @@ function CommonContent(props: CommonContentProps) {
 }
 
 function socketArrayToComponent(
+  socketToInspect: Socket,
   sockets: Socket[],
   props: PropertyArrayContainerProps,
   text: string,
@@ -187,6 +188,7 @@ function socketArrayToComponent(
             {sockets.map((property, index) => {
               return (
                 <SocketContainer
+                  triggerScrollIntoView={socketToInspect === property}
                   key={index}
                   property={property}
                   index={index}
@@ -300,6 +302,9 @@ export const PropertyArrayContainer: React.FunctionComponent<
     false
     // PPGraph.currentGraph.selection.isDraggingSelection
   );
+  const [socketToInspect, setSocketToInspect] = useState<Socket | undefined>(
+    undefined
+  );
 
   const singleNode = props.selectedNodes.length ? props.selectedNodes[0] : null;
   const [selectedNode, setSelectedNode] = useState(singleNode);
@@ -311,6 +316,8 @@ export const PropertyArrayContainer: React.FunctionComponent<
       ListenEvent.SelectionDragging,
       setIsDragging
     );
+    InterfaceController.onOpenInspectorFocusingOnSocket =
+      openInspectorFocusingOnSocket;
     return () => {
       InterfaceController.removeListener(id);
     };
@@ -397,6 +404,10 @@ export const PropertyArrayContainer: React.FunctionComponent<
     });
   };
 
+  const openInspectorFocusingOnSocket = (socket: Socket = null) => {
+    setSocketToInspect(socket);
+  };
+
   return (
     !dragging && (
       <Box sx={{ width: '100%', m: 1 }}>
@@ -430,6 +441,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
           {props.selectedNodes.length === 1 && (
             <>
               {socketArrayToComponent(
+                socketToInspect,
                 selectedNode.nodeTriggerSocketArray,
                 props,
                 'Triggers',
@@ -437,6 +449,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
                 'trigger'
               )}
               {socketArrayToComponent(
+                socketToInspect,
                 selectedNode.inputSocketArray,
                 props,
                 'Inputs',
@@ -444,6 +457,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
                 'in'
               )}
               {socketArrayToComponent(
+                socketToInspect,
                 selectedNode.outputSocketArray,
                 props,
                 'Outputs',

--- a/src/PropertyArrayContainer.tsx
+++ b/src/PropertyArrayContainer.tsx
@@ -290,6 +290,7 @@ function SourceContent(props: SourceContentProps) {
 
 type PropertyArrayContainerProps = {
   selectedNodes: PPNode[];
+  socketToInspect: Socket;
   randomMainColor: string;
   filter: string;
   setFilter: React.Dispatch<React.SetStateAction<string>>;
@@ -302,22 +303,31 @@ export const PropertyArrayContainer: React.FunctionComponent<
     false
     // PPGraph.currentGraph.selection.isDraggingSelection
   );
-  const [socketToInspect, setSocketToInspect] = useState<Socket | undefined>(
-    undefined
-  );
 
   const singleNode = props.selectedNodes.length ? props.selectedNodes[0] : null;
   const [selectedNode, setSelectedNode] = useState(singleNode);
 
   const [configData, setConfigData] = useState(getConfigData(singleNode));
 
+  function switchFilterBasedOnSelectedSocket(node, socket) {
+    switch (true) {
+      case node.nodeTriggerSocketArray.includes(socket):
+        props.setFilter('trigger');
+        break;
+      case node.inputSocketArray.includes(socket):
+        props.setFilter('in');
+        break;
+      case node.outputSocketArray.includes(socket):
+        props.setFilter('out');
+        break;
+    }
+  }
+
   useEffect(() => {
     const id = InterfaceController.addListener(
       ListenEvent.SelectionDragging,
       setIsDragging
     );
-    InterfaceController.onOpenInspectorFocusingOnSocket =
-      openInspectorFocusingOnSocket;
     return () => {
       InterfaceController.removeListener(id);
     };
@@ -329,7 +339,12 @@ export const PropertyArrayContainer: React.FunctionComponent<
     setSelectedNode(newSelectedNode);
     setConfigData(getConfigData(newSelectedNode));
     setUpdatebehaviour(getUpdateBehaviourStateForArray());
+    switchFilterBasedOnSelectedSocket(newSelectedNode, props.socketToInspect);
   }, [props.selectedNodes]);
+
+  useEffect(() => {
+    switchFilterBasedOnSelectedSocket(selectedNode, props.socketToInspect);
+  }, [props.socketToInspect]);
 
   const handleFilter = (
     event: React.MouseEvent<HTMLElement>,
@@ -404,10 +419,6 @@ export const PropertyArrayContainer: React.FunctionComponent<
     });
   };
 
-  const openInspectorFocusingOnSocket = (socket: Socket = null) => {
-    setSocketToInspect(socket);
-  };
-
   return (
     !dragging && (
       <Box sx={{ width: '100%', m: 1 }}>
@@ -441,7 +452,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
           {props.selectedNodes.length === 1 && (
             <>
               {socketArrayToComponent(
-                socketToInspect,
+                props.socketToInspect,
                 selectedNode.nodeTriggerSocketArray,
                 props,
                 'Triggers',
@@ -449,7 +460,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
                 'trigger'
               )}
               {socketArrayToComponent(
-                socketToInspect,
+                props.socketToInspect,
                 selectedNode.inputSocketArray,
                 props,
                 'Inputs',
@@ -457,7 +468,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
                 'in'
               )}
               {socketArrayToComponent(
-                socketToInspect,
+                props.socketToInspect,
                 selectedNode.outputSocketArray,
                 props,
                 'Outputs',

--- a/src/PropertyArrayContainer.tsx
+++ b/src/PropertyArrayContainer.tsx
@@ -54,14 +54,17 @@ function FilterContainer(props: FilterContentProps) {
       </ToggleButton>
       {props.selectedNodes.length === 1 &&
         props.selectedNode.nodeTriggerSocketArray.length > 0 && (
-          <ToggleButton value="trigger" aria-label="trigger">
+          <ToggleButton
+            value="triggerSocketArray"
+            aria-label="triggerSocketArray"
+          >
             Trigger
           </ToggleButton>
         )}
       {props.selectedNodes.length === 1 && (
         <ToggleButton
-          value="in"
-          aria-label="in"
+          value="inputSocketArray"
+          aria-label="inputSocketArray"
           disabled={props.selectedNode.inputSocketArray.length <= 0}
         >
           In
@@ -69,8 +72,8 @@ function FilterContainer(props: FilterContentProps) {
       )}
       {props.selectedNodes.length === 1 && (
         <ToggleButton
-          value="out"
-          aria-label="out"
+          value="outputSocketArray"
+          aria-label="outputSocketArray"
           disabled={props.selectedNode.outputSocketArray.length <= 0}
         >
           Out
@@ -309,17 +312,9 @@ export const PropertyArrayContainer: React.FunctionComponent<
 
   const [configData, setConfigData] = useState(getConfigData(singleNode));
 
-  function switchFilterBasedOnSelectedSocket(node, socket) {
-    switch (true) {
-      case node.nodeTriggerSocketArray.includes(socket):
-        props.setFilter('trigger');
-        break;
-      case node.inputSocketArray.includes(socket):
-        props.setFilter('in');
-        break;
-      case node.outputSocketArray.includes(socket):
-        props.setFilter('out');
-        break;
+  function switchFilterBasedOnSelectedSocket(socket) {
+    if (socket) {
+      props.setFilter(socket.getSocketArrayName());
     }
   }
 
@@ -339,11 +334,11 @@ export const PropertyArrayContainer: React.FunctionComponent<
     setSelectedNode(newSelectedNode);
     setConfigData(getConfigData(newSelectedNode));
     setUpdatebehaviour(getUpdateBehaviourStateForArray());
-    switchFilterBasedOnSelectedSocket(newSelectedNode, props.socketToInspect);
+    switchFilterBasedOnSelectedSocket(props.socketToInspect);
   }, [props.selectedNodes]);
 
   useEffect(() => {
-    switchFilterBasedOnSelectedSocket(selectedNode, props.socketToInspect);
+    switchFilterBasedOnSelectedSocket(props.socketToInspect);
   }, [props.socketToInspect]);
 
   const handleFilter = (
@@ -457,7 +452,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
                 props,
                 'Triggers',
                 props.filter,
-                'trigger'
+                'triggerSocketArray'
               )}
               {socketArrayToComponent(
                 props.socketToInspect,
@@ -465,7 +460,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
                 props,
                 'Inputs',
                 props.filter,
-                'in'
+                'inputSocketArray'
               )}
               {socketArrayToComponent(
                 props.socketToInspect,
@@ -473,7 +468,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
                 props,
                 'Outputs',
                 props.filter,
-                'out'
+                'outputSocketArray'
               )}
               {(props.filter === 'source' || props.filter == null) && (
                 <Stack spacing={1}>

--- a/src/PropertyArrayContainer.tsx
+++ b/src/PropertyArrayContainer.tsx
@@ -54,17 +54,14 @@ function FilterContainer(props: FilterContentProps) {
       </ToggleButton>
       {props.selectedNodes.length === 1 &&
         props.selectedNode.nodeTriggerSocketArray.length > 0 && (
-          <ToggleButton
-            value="triggerSocketArray"
-            aria-label="triggerSocketArray"
-          >
+          <ToggleButton value="trigger" aria-label="trigger">
             Trigger
           </ToggleButton>
         )}
       {props.selectedNodes.length === 1 && (
         <ToggleButton
-          value="inputSocketArray"
-          aria-label="inputSocketArray"
+          value="in"
+          aria-label="in"
           disabled={props.selectedNode.inputSocketArray.length <= 0}
         >
           In
@@ -72,8 +69,8 @@ function FilterContainer(props: FilterContentProps) {
       )}
       {props.selectedNodes.length === 1 && (
         <ToggleButton
-          value="outputSocketArray"
-          aria-label="outputSocketArray"
+          value="out"
+          aria-label="out"
           disabled={props.selectedNode.outputSocketArray.length <= 0}
         >
           Out
@@ -312,9 +309,9 @@ export const PropertyArrayContainer: React.FunctionComponent<
 
   const [configData, setConfigData] = useState(getConfigData(singleNode));
 
-  function switchFilterBasedOnSelectedSocket(socket) {
+  function switchFilterBasedOnSelectedSocket(socket: Socket) {
     if (socket) {
-      props.setFilter(socket.getSocketArrayName());
+      props.setFilter(socket.socketType);
     }
   }
 
@@ -452,7 +449,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
                 props,
                 'Triggers',
                 props.filter,
-                'triggerSocketArray'
+                'trigger'
               )}
               {socketArrayToComponent(
                 props.socketToInspect,
@@ -460,7 +457,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
                 props,
                 'Inputs',
                 props.filter,
-                'inputSocketArray'
+                'in'
               )}
               {socketArrayToComponent(
                 props.socketToInspect,
@@ -468,7 +465,7 @@ export const PropertyArrayContainer: React.FunctionComponent<
                 props,
                 'Outputs',
                 props.filter,
-                'outputSocketArray'
+                'out'
               )}
               {(props.filter === 'source' || props.filter == null) && (
                 <Stack spacing={1}>

--- a/src/SocketContainer.tsx
+++ b/src/SocketContainer.tsx
@@ -86,7 +86,7 @@ export const SocketContainer: React.FunctionComponent<SocketContainerProps> = (
       <Box
         sx={{
           px: 1,
-          pb: 1,
+          py: 1,
           ...(!showHeader && { margin: '0px' }), // if no header, then override the margins
         }}
         className={styles.propertyContainerContent}

--- a/src/SocketContainer.tsx
+++ b/src/SocketContainer.tsx
@@ -57,15 +57,12 @@ export const SocketContainer: React.FunctionComponent<SocketContainerProps> = (
   };
 
   const CustomSocketInjection = ({ InjectionContent, props }) => {
-    console.log(props);
-
     return <InjectionContent {...props} />;
   };
 
   useEffect(() => {
     if (props.triggerScrollIntoView) {
       myRef.current.scrollIntoView({
-        behavior: 'smooth',
         block: 'center',
         inline: 'nearest',
       });

--- a/src/SocketContainer.tsx
+++ b/src/SocketContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Color from 'color';
 import { Box, IconButton, Menu, MenuItem, ToggleButton } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
@@ -14,6 +14,7 @@ import { AbstractType } from './nodes/datatypes/abstractType';
 import { allDataTypes } from './nodes/datatypes/dataTypesMap';
 
 type SocketContainerProps = {
+  triggerScrollIntoView: boolean;
   property: Socket;
   index: number;
   dataType: AbstractType;
@@ -28,6 +29,8 @@ type SocketContainerProps = {
 export const SocketContainer: React.FunctionComponent<SocketContainerProps> = (
   props
 ) => {
+  const myRef = useRef(null);
+
   const { showHeader = true } = props;
   const [dataTypeValue, setDataTypeValue] = useState(props.dataType);
   const baseProps = {
@@ -59,13 +62,24 @@ export const SocketContainer: React.FunctionComponent<SocketContainerProps> = (
     return <InjectionContent {...props} />;
   };
 
+  useEffect(() => {
+    if (props.triggerScrollIntoView) {
+      myRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'nearest',
+      });
+    }
+  }, [props.triggerScrollIntoView]);
+
   return (
-    <Box sx={{ bgcolor: 'background.default' }}>
+    <Box ref={myRef} sx={{ bgcolor: 'background.default' }}>
       {showHeader && (
         <SocketHeader
           key={`SocketHeader-${props.dataType.getName()}`}
           property={props.property}
           index={props.index}
+          isSelected={props.triggerScrollIntoView}
           isInput={props.isInput}
           hasLink={props.hasLink}
           onChangeDropdown={onChangeDropdown}
@@ -101,6 +115,7 @@ export const SocketContainer: React.FunctionComponent<SocketContainerProps> = (
 type SocketHeaderProps = {
   property: Socket;
   index: number;
+  isSelected: boolean;
   isInput: boolean;
   hasLink: boolean;
   onChangeDropdown: (event) => void;
@@ -124,6 +139,7 @@ const SocketHeader: React.FunctionComponent<SocketHeaderProps> = (props) => {
         display: 'flex',
         flexWrap: 'nowrap',
         width: '100%',
+        bgcolor: props.isSelected && 'secondary.dark',
       }}
     >
       <ToggleButton

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -327,7 +327,13 @@ export default class PPGraph {
     if (event.data.originalEvent.ctrlKey) {
       InterfaceController.onOpenSocketInspector(clickedSourcePoint, socket);
     } else {
-      InterfaceController.onOpenInspectorFocusingOnSocket(socket);
+      InterfaceController.notifyListeners(ListenEvent.SelectionChanged, [
+        socket.getNode(),
+      ]);
+      InterfaceController.notifyListeners(
+        ListenEvent.OpenInspectorFocusingOnSocket,
+        socket
+      );
     }
   }
 

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -2,14 +2,13 @@
 import * as PIXI from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 
-import { NODE_WIDTH, PP_VERSION, SOCKET_TYPE } from '../utils/constants';
+import { NODE_WIDTH, PP_VERSION } from '../utils/constants';
 import {
   CustomArgs,
   SerializedGraph,
   SerializedLink,
   SerializedNode,
   SerializedSelection,
-  TSocketType,
 } from '../utils/interfaces';
 import { connectNodeToSocket } from '../utils/utils';
 import { getNodesBounds } from '../pixi/utils-pixi';
@@ -33,6 +32,7 @@ export default class PPGraph {
 
   _showComments: boolean;
   _showExecutionVisualisation: boolean;
+  socketToInspect: null | PPSocket;
   selectedSourceSocket: null | PPSocket;
   lastSelectedSocketWasInput = false;
   overrideNodeCursorPosition: null | PIXI.Point = null;
@@ -238,7 +238,7 @@ export default class PPGraph {
       }
 
       // swap points if i grabbed an input, to make curve look nice
-      if (this.selectedSourceSocket.socketType === SOCKET_TYPE.IN) {
+      if (this.selectedSourceSocket.isInput()) {
         const temp: PIXI.Point = targetPoint;
         targetPoint = socketCenter;
         socketCenter = temp;
@@ -277,7 +277,7 @@ export default class PPGraph {
   }
 
   socketMouseDown(socket: PPSocket, event: PIXI.InteractionEvent): void {
-    const overOutput = socket.socketType == SOCKET_TYPE.OUT;
+    const overOutput = socket.isOutput();
     this.lastSelectedSocketWasInput = overOutput;
     if (overOutput) {
       this.selectedSourceSocket = socket;
@@ -302,15 +302,9 @@ export default class PPGraph {
     const source = this.selectedSourceSocket;
     this.stopConnecting();
     if (source && socket !== this.selectedSourceSocket) {
-      if (
-        source.socketType === SOCKET_TYPE.IN &&
-        socket.socketType === SOCKET_TYPE.OUT
-      ) {
+      if (source.isInput() && socket.isOutput()) {
         await this.action_Connect(socket, source);
-      } else if (
-        source.socketType === SOCKET_TYPE.OUT &&
-        socket.socketType === SOCKET_TYPE.IN
-      ) {
+      } else if (source.isOutput() && socket.isInput()) {
         await this.action_Connect(source, socket);
       }
     }
@@ -330,9 +324,14 @@ export default class PPGraph {
       InterfaceController.notifyListeners(ListenEvent.SelectionChanged, [
         socket.getNode(),
       ]);
+      if (this.socketToInspect !== socket) {
+        this.socketToInspect = socket;
+      } else {
+        this.socketToInspect = null;
+      }
       InterfaceController.notifyListeners(
         ListenEvent.OpenInspectorFocusingOnSocket,
-        socket
+        this.socketToInspect
       );
     }
   }
@@ -448,15 +447,13 @@ export default class PPGraph {
   }
 
   async addSerializedLink(link: SerializedLink): Promise<void> {
-    const outputRef = this.getSocket(
+    const outputRef = this.getOutputSocket(
       link.sourceNodeId,
-      link.sourceSocketName,
-      SOCKET_TYPE.OUT
+      link.sourceSocketName
     );
-    const inputRef = this.getSocket(
+    const inputRef = this.getInputSocket(
       link.targetNodeId,
-      link.targetSocketName,
-      SOCKET_TYPE.IN
+      link.targetSocketName
     );
     if (outputRef && inputRef) {
       await this.connect(outputRef, inputRef, false);
@@ -553,14 +550,14 @@ export default class PPGraph {
   ) {
     await this.connect(
       this.nodes[sourceNodeID].getOutputSocketByName(outputSocketName),
-      this.nodes[targetNodeID].getInputSocketByName(inputSocketName),
+      this.nodes[targetNodeID].getInputOrTriggerSocketByName(inputSocketName),
       notify
     );
   }
 
   async linkDisconnect(targetNodeID, inputSocketName) {
     this.nodes[targetNodeID]
-      .getInputSocketByName(inputSocketName)
+      .getInputOrTriggerSocketByName(inputSocketName)
       .links[0].delete();
   }
 
@@ -774,7 +771,7 @@ export default class PPGraph {
           ].getOutputSocketByName(link.sourceSocketName);
           const newTarget = mappingOfOldAndNewNodes[
             link.targetNodeId
-          ].getInputSocketByName(link.targetSocketName);
+          ].getInputOrTriggerSocketByName(link.targetSocketName);
           await this.connect(newSource, newTarget, false);
         })
       );
@@ -794,7 +791,7 @@ export default class PPGraph {
   }
 
   addTriggerInput(): void {
-    this.selection.selectedNodes.forEach((node) => node.addTriggerInput());
+    this.selection.selectedNodes.forEach((node) => node.addDefaultTrigger());
   }
 
   async extractToMacro(): Promise<void> {
@@ -830,7 +827,7 @@ export default class PPGraph {
     inputs.forEach(async (socket, i) => {
       const newSocket = forwardMapping[
         socket.getNode().id
-      ].getInputSocketByName(socket.name);
+      ].getInputOrTriggerSocketByName(socket.name);
       await this.connect(macroNode.outputSocketArray[i], newSocket);
     });
 
@@ -1025,14 +1022,14 @@ export default class PPGraph {
     return true;
   }
 
-  getSocket(nodeID: string, socketName: string, type: TSocketType): PPSocket {
+  getInputSocket(nodeID: string, socketName: string): PPSocket {
     const node = this.getNodeById(nodeID);
-    if (node) {
-      return type === SOCKET_TYPE.IN
-        ? node.getInputSocketByName(socketName)
-        : node.getOutputSocketByName(socketName);
-    }
-    return undefined;
+    return node.getInputOrTriggerSocketByName(socketName);
+  }
+
+  getOutputSocket(nodeID: string, socketName: string): PPSocket {
+    const node = this.getNodeById(nodeID);
+    return node.getOutputSocketByName(socketName);
   }
 
   tick(currentTime: number, deltaTime: number): void {
@@ -1105,7 +1102,7 @@ export default class PPGraph {
           this.nodes[link.sourceNodeId].getOutputSocketByName(
             link.sourceSocketName
           ),
-          this.nodes[link.targetNodeId].getInputSocketByName(
+          this.nodes[link.targetNodeId].getInputOrTriggerSocketByName(
             link.targetSocketName
           ),
           false

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -324,7 +324,11 @@ export default class PPGraph {
       event.data.global.x,
       event.data.global.y
     );
-    InterfaceController.onOpenSocketInspector(clickedSourcePoint, socket);
+    if (event.data.originalEvent.ctrlKey) {
+      InterfaceController.onOpenSocketInspector(clickedSourcePoint, socket);
+    } else {
+      InterfaceController.onOpenInspectorFocusingOnSocket(socket);
+    }
   }
 
   // GETTERS & SETTERS

--- a/src/classes/SocketClass.ts
+++ b/src/classes/SocketClass.ts
@@ -301,6 +301,17 @@ export default class Socket extends PIXI.Container {
     return this.parent as PPNode;
   }
 
+  getSocketArrayName(): string {
+    switch (true) {
+      case this.getNode().inputSocketArray.includes(this):
+        return 'inputSocketArray';
+      case this.getNode().outputSocketArray.includes(this):
+        return 'outputSocketArray';
+      case this.getNode().nodeTriggerSocketArray.includes(this):
+        return 'triggerSocketArray';
+    }
+  }
+
   getGraph(): PPGraph {
     return PPGraph.currentGraph;
   }

--- a/src/classes/SocketClass.ts
+++ b/src/classes/SocketClass.ts
@@ -54,7 +54,7 @@ export default class Socket extends PIXI.Container {
   ) {
     super();
 
-    if (socketType === SOCKET_TYPE.IN) {
+    if (socketType !== SOCKET_TYPE.OUT) {
       // define defaultData for different types
       if (data === null && dataType) {
         data = dataType.getDefaultValue();
@@ -78,7 +78,7 @@ export default class Socket extends PIXI.Container {
 
   getSocketLocation(): PIXI.Point {
     return new PIXI.Point(
-      this.socketType === SOCKET_TYPE.IN
+      this.isInput()
         ? this.getNode()?.getInputSocketXPos() + SOCKET_WIDTH / 2
         : this.getNode()?.getOutputSocketXPos() + SOCKET_WIDTH / 2,
       SOCKET_WIDTH / 2
@@ -145,10 +145,9 @@ export default class Socket extends PIXI.Container {
         this._TextRef.anchor.set(1, 0);
         this._TextRef.name = 'TextRef';
       }
-      this._TextRef.x =
-        this.socketType === SOCKET_TYPE.IN
-          ? this.getSocketLocation().x + SOCKET_WIDTH / 2 + SOCKET_TEXTMARGIN
-          : this.getSocketLocation().x - SOCKET_TEXTMARGIN - SOCKET_WIDTH / 2;
+      this._TextRef.x = this.isInput()
+        ? this.getSocketLocation().x + SOCKET_WIDTH / 2 + SOCKET_TEXTMARGIN
+        : this.getSocketLocation().x - SOCKET_TEXTMARGIN - SOCKET_WIDTH / 2;
       this._TextRef.y = SOCKET_TEXTMARGIN_TOP;
       this._TextRef.resolution = TEXT_RESOLUTION;
 
@@ -260,7 +259,14 @@ export default class Socket extends PIXI.Container {
   // METHODS
 
   isInput(): boolean {
-    return this.socketType === SOCKET_TYPE.IN;
+    return (
+      this.socketType === SOCKET_TYPE.IN ||
+      this.socketType === SOCKET_TYPE.TRIGGER
+    );
+  }
+
+  isOutput(): boolean {
+    return this.socketType === SOCKET_TYPE.OUT;
   }
 
   hasLink(): boolean {
@@ -299,17 +305,6 @@ export default class Socket extends PIXI.Container {
 
   getNode(): PPNode {
     return this.parent as PPNode;
-  }
-
-  getSocketArrayName(): string {
-    switch (true) {
-      case this.getNode().inputSocketArray.includes(this):
-        return 'inputSocketArray';
-      case this.getNode().outputSocketArray.includes(this):
-        return 'outputSocketArray';
-      case this.getNode().nodeTriggerSocketArray.includes(this):
-        return 'triggerSocketArray';
-    }
   }
 
   getGraph(): PPGraph {

--- a/src/components/ContextMenus.tsx
+++ b/src/components/ContextMenus.tsx
@@ -219,7 +219,7 @@ export const GraphContextMenu = (props) => {
         </MenuItem>
         <MenuItem
           onClick={() => {
-            props.setShowLeftSideDrawer();
+            props.setShowRightSideDrawer();
           }}
         >
           <ListItemIcon>
@@ -379,7 +379,7 @@ export const NodeContextMenu = (props) => {
         </MenuItem>
         <MenuItem
           onClick={() => {
-            props.setShowLeftSideDrawer();
+            props.setShowRightSideDrawer();
           }}
         >
           <ListItemIcon>

--- a/src/components/FloatingSocketInspector.tsx
+++ b/src/components/FloatingSocketInspector.tsx
@@ -130,6 +130,7 @@ export const FloatingSocketInspector: React.FunctionComponent<MyProps> = (
         </Box>
         <Box id="draggable-content">
           <SocketContainer
+            triggerScrollIntoView={false}
             key={0}
             property={props.socketToInspect}
             index={0}

--- a/src/components/GraphOverlay.tsx
+++ b/src/components/GraphOverlay.tsx
@@ -50,6 +50,15 @@ const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
     };
   });
 
+  useEffect(() => {
+    InterfaceController.onOpenInspectorFocusingOnSocket =
+      openInspectorFocusingOnSocket;
+  });
+
+  const openInspectorFocusingOnSocket = (socket = null) => {
+    setSelectedNodes([socket.getNode()]);
+  };
+
   return (
     <>
       <GraphOverlayDrawer

--- a/src/components/GraphOverlay.tsx
+++ b/src/components/GraphOverlay.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PPGraph from '../classes/GraphClass';
 import PPNode from '../classes/NodeClass';
+import Socket from '../classes/SocketClass';
 import InterfaceController, { ListenEvent } from '../InterfaceController';
 import GraphOverlayDrawer from './GraphOverlayDrawer';
 import GraphOverlaySocketInspector from './GraphOverlaySocketInspector';
@@ -13,6 +14,9 @@ type GraphOverlayProps = {
 
 const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
   const [selectedNodes, setSelectedNodes] = useState<PPNode[]>([]);
+  const [socketToInspect, setSocketToInspect] = useState<Socket | undefined>(
+    undefined
+  );
   const [isDraggingSelection, setIsDraggingSelection] = useState(false);
   const [isDraggingViewport, setIsDraggingViewport] = useState(false);
   const [isZoomingViewport, setIsZoomingViewport] = useState(false);
@@ -44,26 +48,24 @@ const GraphOverlay: React.FunctionComponent<GraphOverlayProps> = (props) => {
         setIsZoomingViewport
       )
     );
+    ids.push(
+      InterfaceController.addListener(
+        ListenEvent.OpenInspectorFocusingOnSocket,
+        setSocketToInspect
+      )
+    );
 
     return () => {
       ids.forEach((id) => InterfaceController.removeListener(id));
     };
-  });
-
-  useEffect(() => {
-    InterfaceController.onOpenInspectorFocusingOnSocket =
-      openInspectorFocusingOnSocket;
-  });
-
-  const openInspectorFocusingOnSocket = (socket = null) => {
-    setSelectedNodes([socket.getNode()]);
-  };
+  }, []);
 
   return (
     <>
       <GraphOverlayDrawer
         toggle={props.toggle}
         selectedNodes={selectedNodes}
+        socketToInspect={socketToInspect}
         randomMainColor={props.randomMainColor}
       />
       <GraphOverlaySocketInspector randomMainColor={props.randomMainColor} />

--- a/src/components/GraphOverlayDrawer.tsx
+++ b/src/components/GraphOverlayDrawer.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { Box } from '@mui/material';
 import PPNode from '../classes/NodeClass';
+import Socket from '../classes/SocketClass';
 import ResponsiveDrawer from './ResponsiveDrawer';
 
 type GraphOverlayDrawerProps = {
   randomMainColor: string;
   selectedNodes: PPNode[];
+  socketToInspect: Socket;
   toggle: boolean;
 };
 
@@ -23,6 +25,7 @@ const GraphOverlayDrawer: React.FunctionComponent<GraphOverlayDrawerProps> = (
         setDrawerWidth={setDrawerWidth}
         toggle={props.toggle}
         selectedNodes={props.selectedNodes}
+        socketToInspect={props.socketToInspect}
         randomMainColor={props.randomMainColor}
       />
     </Box>

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -113,6 +113,7 @@ const ResponsiveDrawer = (props) => {
         {props.selectedNodes.length ? (
           <InspectorContainer
             selectedNodes={props.selectedNodes}
+            socketToInspect={props.socketToInspect}
             randomMainColor={props.randomMainColor}
             filter={filter}
             setFilter={setFilter}

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -96,7 +96,7 @@ const ResponsiveDrawer = (props) => {
             width: props.drawerWidth,
             border: 0,
             background: `${Color(props.randomMainColor).alpha(0.8)}`,
-            overflowY: 'hidden',
+            overflowY: 'unset',
             height: '100vh',
           },
         }}

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -42,7 +42,7 @@ function DrawerToggle(props) {
 const ResponsiveDrawer = (props) => {
   // leaving this commented here for potential future testing
   const [open, setOpen] = useState(true);
-  const [filter, setFilter] = useState('in');
+  const [filter, setFilter] = useState('inputSocketArray');
 
   const handleDrawerToggle = () => {
     setOpen((prevState) => !prevState);

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -42,7 +42,7 @@ function DrawerToggle(props) {
 const ResponsiveDrawer = (props) => {
   // leaving this commented here for potential future testing
   const [open, setOpen] = useState(true);
-  const [filter, setFilter] = useState('inputSocketArray');
+  const [filter, setFilter] = useState('in');
 
   const handleDrawerToggle = () => {
     setOpen((prevState) => !prevState);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,7 @@ root.render(
   <ThemeProvider theme={customTheme}>
     <SnackbarProvider
       maxSnack={9}
-      anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+      anchorOrigin={{ horizontal: 'center', vertical: 'top' }}
       classes={{
         containerRoot: styles.snackbarContainerRoot,
       }}

--- a/src/nodes/graphSegments/simpleBarGraph.json
+++ b/src/nodes/graphSegments/simpleBarGraph.json
@@ -17,7 +17,6 @@
       "y": 647.003786656838,
       "width": 1618.580412622444,
       "height": 839.2388422837168,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -95,7 +94,6 @@
       "y": 744.8871675249594,
       "width": 160,
       "height": 208,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -224,7 +222,6 @@
       "y": 1659.6293571808847,
       "width": 2548.7486169158406,
       "height": 1313.8876152799908,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -314,7 +311,6 @@
       "y": 1669.2816334428917,
       "width": 160,
       "height": 280,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -412,7 +408,6 @@
       "y": 41.18133415959801,
       "width": 160,
       "height": 304,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -537,7 +532,6 @@
       "y": 1927.7200160793295,
       "width": 160,
       "height": 184,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -654,7 +648,6 @@
       "y": 25.99251002030178,
       "width": 160,
       "height": 136,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -750,7 +743,6 @@
       "y": 990.306390780584,
       "width": 160,
       "height": 208,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -879,7 +871,6 @@
       "y": 780.172741894243,
       "width": 160,
       "height": 136,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -982,7 +973,6 @@
       "y": 794.3848847203209,
       "width": 160,
       "height": 112,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1026,7 +1016,6 @@
       "y": 2051.1745410939448,
       "width": 160,
       "height": 136,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1070,7 +1059,6 @@
       "y": 390.71012056799236,
       "width": 191.23670833703602,
       "height": 86.94695098455622,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1121,7 +1109,6 @@
       "y": 1891.6711473237842,
       "width": 160,
       "height": 136,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1224,7 +1211,6 @@
       "y": 2172.019850860394,
       "width": 160,
       "height": 232,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1353,7 +1339,6 @@
       "y": 2327.719317892924,
       "width": 160,
       "height": 112,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1397,7 +1382,6 @@
       "y": 2343.9221640512073,
       "width": 160,
       "height": 88,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1434,7 +1418,6 @@
       "y": 2304.5070728986707,
       "width": 160,
       "height": 112,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1478,7 +1461,6 @@
       "y": 2131.8866741416746,
       "width": 160,
       "height": 112,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1522,7 +1504,6 @@
       "y": 2097.352582208711,
       "width": 160,
       "height": 88,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1559,7 +1540,6 @@
       "y": 2515.7333641290206,
       "width": 480.2135416666667,
       "height": 68.8,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1615,7 +1595,6 @@
       "y": 2557.845391577378,
       "width": 160,
       "height": 232,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1744,7 +1723,6 @@
       "y": 2348.137350273328,
       "width": 160,
       "height": 136,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1847,7 +1825,6 @@
       "y": 480.64021747071956,
       "width": 189.91040901931785,
       "height": 84.1837749655324,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1898,7 +1875,6 @@
       "y": 961.0431907707214,
       "width": 160,
       "height": 136,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -1942,7 +1918,6 @@
       "y": 1140.076091180593,
       "width": 160,
       "height": 136,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -2045,7 +2020,6 @@
       "y": 1246.995676047567,
       "width": 160,
       "height": 208,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -2174,7 +2148,6 @@
       "y": 116.06827486432803,
       "width": 160,
       "height": 64,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -2228,7 +2201,6 @@
       "y": 1210.2326094439518,
       "width": 160,
       "height": 88,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -2265,7 +2237,6 @@
       "y": 163.35737930934556,
       "width": 160,
       "height": 87.52424546903603,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -2330,7 +2301,6 @@
       "y": 255.3490057641011,
       "width": 160,
       "height": 82.08582293178097,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",
@@ -2395,7 +2365,6 @@
       "y": 341.85852804959313,
       "width": 162.39736192629854,
       "height": 85.85689186757327,
-      "triggerArray": [],
       "socketArray": [
         {
           "socketType": "in",

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -126,6 +126,7 @@ export const TEXT_RESOLUTION = 8; // so one can zoom in closer and it keeps a de
 export const SOCKET_TYPE = {
   IN: 'in',
   OUT: 'out',
+  TRIGGER: 'trigger',
 } as const;
 
 export const SOCKET_COLOR_HEX: string = Color(COLOR[0]).lighten(0.4).hex();

--- a/src/utils/interfaces.tsx
+++ b/src/utils/interfaces.tsx
@@ -17,7 +17,7 @@ export type RegisteredNodeTypes = Record<
 export type PPNodeConstructor<T extends PPNode = PPNode> = {
   type?: string;
   category?: string;
-  new(name: string, ...args: any[]): T;
+  new (name: string, ...args: any[]): T;
 };
 
 export type SerializedGraph = {
@@ -76,7 +76,6 @@ export type SerializedNode = {
   y: number;
   width: number;
   height: number;
-  triggerArray: SerializedSocket[];
   socketArray: SerializedSocket[];
   updateBehaviour: IUpdateBehaviour;
 };
@@ -203,6 +202,11 @@ export class TRgba {
   }
 
   public static randomColor(): TRgba {
-    return new TRgba(Math.random() * 255, Math.random() * 255, Math.random() * 255, 1);
+    return new TRgba(
+      Math.random() * 255,
+      Math.random() * 255,
+      Math.random() * 255,
+      1
+    );
   }
 }

--- a/src/utils/style.module.css
+++ b/src/utils/style.module.css
@@ -193,8 +193,8 @@
 
 .userMenu {
   position: absolute;
-  right: 8px;
-  top: 4px;
+  left: 24px;
+  top: 96px;
   filter: drop-shadow(0px 0px 24px rgba(0, 0, 0, 0.15));
   z-index: 10;
 }

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -391,7 +391,6 @@ export const TriggerWidget: React.FunctionComponent<TriggerWidgetProps> = (
   props
 ) => {
   const [data, setData] = useState(props.data);
-  console.log(props);
   const [triggerType, setChangeFunctionString] = useState(
     props.type.triggerType
   );


### PR DESCRIPTION
* When clicking on a socket
  * the inspector opens
  * switches to the respective filter
  * scrolls to and marks the socket
* moved the toast messages to appear in the center, to not cover the drawer button
* moved the share button to the top left


https://user-images.githubusercontent.com/4619772/215353983-baccb990-f80a-4988-9960-c49baa60cf0e.mov

