### PR TITLE
Fix dropdown/enum options and some cleanup

### DIFF
--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -725,7 +725,7 @@ export default class PPNode extends PIXI.Container {
       new Socket(
         SOCKET_TYPE.IN,
         this.constructSocketName('Trigger', this.nodeTriggerSocketArray),
-        new TriggerType(TRIGGER_TYPE_OPTIONS[0].value),
+        new TriggerType(TRIGGER_TYPE_OPTIONS[0].text),
         0,
         true
       )

--- a/src/nodes/base.ts
+++ b/src/nodes/base.ts
@@ -5,6 +5,7 @@ import _ from 'lodash-contrib';
 import PPGraph from '../classes/GraphClass';
 import PPNode from '../classes/NodeClass';
 import PPSocket from '../classes/SocketClass';
+import UpdateBehaviourClass from '../classes/UpdateBehaviourClass';
 import {
   COLOR,
   COMPARISON_OPTIONS,
@@ -307,15 +308,13 @@ export class RandomArray extends PPNode {
     return 'Create random array';
   }
 
+  protected getUpdateBehaviour(): UpdateBehaviourClass {
+    return new UpdateBehaviourClass(false, false, 10000);
+  }
+
   protected getDefaultIO(): PPSocket[] {
     return [
       new PPSocket(SOCKET_TYPE.OUT, 'output array', new ArrayType()),
-      new PPSocket(
-        SOCKET_TYPE.IN,
-        'trigger',
-        new TriggerType(TRIGGER_TYPE_OPTIONS[0].value, 'trigger'),
-        0
-      ),
       new PPSocket(
         SOCKET_TYPE.IN,
         'length',
@@ -323,19 +322,22 @@ export class RandomArray extends PPNode {
         20,
         undefined
       ),
-      new PPSocket(SOCKET_TYPE.IN, 'min', new NumberType(), 0),
-      new PPSocket(SOCKET_TYPE.IN, 'max', new NumberType(), 1),
+      new PPSocket(SOCKET_TYPE.IN, 'min', new NumberType(true), 0),
+      new PPSocket(SOCKET_TYPE.IN, 'max', new NumberType(true), 100),
     ].concat(super.getDefaultIO());
   }
 
-  trigger(): void {
-    const length = this.getInputData('length');
-    const min = this.getInputData('min');
-    const max = this.getInputData('max');
+  protected async onExecute(
+    inputObject: any,
+    outputObject: Record<string, unknown>
+  ): Promise<void> {
+    const length = inputObject['length'];
+    const min = inputObject['min'];
+    const max = inputObject['max'];
     const randomArray = Array.from({ length: length }, () => {
       return Math.floor(Math.random() * (max - min) + min);
     });
-    this.setOutputData('output array', randomArray);
+    outputObject['output array'] = randomArray;
   }
 }
 
@@ -366,7 +368,6 @@ export class DateAndTime extends PPNode {
       .map((methodName) => {
         return {
           text: methodName,
-          value: methodName,
         };
       });
 

--- a/src/nodes/base.ts
+++ b/src/nodes/base.ts
@@ -25,7 +25,6 @@ import {
 import { NumberType } from './datatypes/numberType';
 import { AnyType } from './datatypes/anyType';
 import { ArrayType } from './datatypes/arrayType';
-import { TriggerType } from './datatypes/triggerType';
 import { ColorType } from './datatypes/colorType';
 import { StringType } from './datatypes/stringType';
 import { EnumType } from './datatypes/enumType';

--- a/src/nodes/data/array.tsx
+++ b/src/nodes/data/array.tsx
@@ -50,7 +50,6 @@ export class ArrayMethod extends PPNode {
       .map((methodName) => {
         return {
           text: methodName,
-          value: methodName,
         };
       });
 

--- a/src/nodes/datatypes/triggerType.tsx
+++ b/src/nodes/datatypes/triggerType.tsx
@@ -9,7 +9,7 @@ export class TriggerType extends AbstractType {
   customFunctionString: string;
   previousData: any = null;
   constructor(
-    triggerType = TRIGGER_TYPE_OPTIONS[0].value,
+    triggerType = TRIGGER_TYPE_OPTIONS[0].text,
     customFunctionString = ''
   ) {
     super();
@@ -42,11 +42,11 @@ export class TriggerType extends AbstractType {
     super.onDataSet(data, socket);
     if (
       socket.isInput() &&
-      ((this.triggerType === TRIGGER_TYPE_OPTIONS[0].value &&
+      ((this.triggerType === TRIGGER_TYPE_OPTIONS[0].text &&
         this.previousData < data) ||
-        (this.triggerType === TRIGGER_TYPE_OPTIONS[1].value &&
+        (this.triggerType === TRIGGER_TYPE_OPTIONS[1].text &&
           this.previousData > data) ||
-        (this.triggerType === TRIGGER_TYPE_OPTIONS[2].value &&
+        (this.triggerType === TRIGGER_TYPE_OPTIONS[2].text &&
           this.previousData !== data))
     ) {
       // if im an input and condition is fullfilled, execute either custom function or start new chain with this as origin

--- a/src/nodes/draw/abstract.tsx
+++ b/src/nodes/draw/abstract.tsx
@@ -93,7 +93,7 @@ export abstract class DRAW_Base extends PPNode {
         SOCKET_TYPE.IN,
         inputPivotName,
         new EnumType(PIXI_PIVOT_OPTIONS),
-        PIXI_PIVOT_OPTIONS[0].value,
+        PIXI_PIVOT_OPTIONS[0].text,
         false
       ),
       new Socket(
@@ -234,7 +234,10 @@ export abstract class DRAW_Base extends PPNode {
   }
 
   protected positionAndScale(toModify: DisplayObject, inputObject: any): void {
-    const pivotPoint = inputObject[inputPivotName];
+    const pivot = inputObject[inputPivotName];
+    const pivotPoint = PIXI_PIVOT_OPTIONS.find(
+      (option) => option.text === pivot
+    ).value;
 
     toModify.setTransform(
       inputObject[offseXName],

--- a/src/nodes/draw/draw.tsx
+++ b/src/nodes/draw/draw.tsx
@@ -19,19 +19,15 @@ import { DRAW_Base, injectedDataName, outputPixiName } from './abstract';
 const availableShapes: EnumStructure = [
   {
     text: 'Circle',
-    value: 'Circle',
   },
   {
     text: 'Rectangle',
-    value: 'Rectangle',
   },
   {
     text: 'Rounded Rectangle',
-    value: 'Rounded Rectangle',
   },
   {
     text: 'Ellipse',
-    value: 'Ellipse',
   },
 ];
 
@@ -86,7 +82,12 @@ export class DRAW_Shape extends DRAW_Base {
         new EnumType(availableShapes),
         'Circle'
       ),
-      new Socket(SOCKET_TYPE.IN, inputColorName, new ColorType(), TRgba.randomColor()),
+      new Socket(
+        SOCKET_TYPE.IN,
+        inputColorName,
+        new ColorType(),
+        TRgba.randomColor()
+      ),
       new Socket(
         SOCKET_TYPE.IN,
         inputWidthName,
@@ -111,7 +112,7 @@ export class DRAW_Shape extends DRAW_Base {
     inputObject = {
       ...inputObject,
       ...inputObject[injectedDataName][
-      this.getAndIncrementExecutions(executions)
+        this.getAndIncrementExecutions(executions)
       ],
     };
     const width = inputObject[inputWidthName];
@@ -178,7 +179,7 @@ export class DRAW_Passthrough extends DRAW_Base {
     inputObject = {
       ...inputObject,
       ...inputObject[injectedDataName][
-      this.getAndIncrementExecutions(executions)
+        this.getAndIncrementExecutions(executions)
       ],
     };
     const myContainer = new PIXI.Container();
@@ -234,7 +235,7 @@ export class DRAW_Text extends DRAW_Base {
     inputObject = {
       ...inputObject,
       ...inputObject[injectedDataName][
-      this.getAndIncrementExecutions(executions)
+        this.getAndIncrementExecutions(executions)
       ],
     };
     const textStyle = new PIXI.TextStyle({
@@ -278,7 +279,7 @@ export class DRAW_Combine extends DRAW_Base {
     inputObject = {
       ...inputObject,
       ...inputObject[injectedDataName][
-      this.getAndIncrementExecutions(executions)
+        this.getAndIncrementExecutions(executions)
       ],
     };
     const myContainer = new PIXI.Container();
@@ -333,7 +334,7 @@ export class DRAW_COMBINE_ARRAY extends DRAW_Base {
     inputObject = {
       ...inputObject,
       ...inputObject[injectedDataName][
-      this.getAndIncrementExecutions(executions)
+        this.getAndIncrementExecutions(executions)
       ],
     };
     const myContainer = new PIXI.Container();
@@ -409,7 +410,7 @@ export class DRAW_Multiplier extends DRAW_Base {
     inputObject = {
       ...inputObject,
       ...inputObject[injectedDataName][
-      this.getAndIncrementExecutions(executions)
+        this.getAndIncrementExecutions(executions)
       ],
     };
     const myContainer = new PIXI.Container();
@@ -489,7 +490,7 @@ export class DRAW_Multipy_Along extends DRAW_Base {
     inputObject = {
       ...inputObject,
       ...inputObject[injectedDataName][
-      this.getAndIncrementExecutions(executions)
+        this.getAndIncrementExecutions(executions)
       ],
     };
     const myContainer = new PIXI.Container();
@@ -531,7 +532,7 @@ export class DRAW_Image extends DRAW_Base {
     inputObject = {
       ...inputObject,
       ...inputObject[injectedDataName][
-      this.getAndIncrementExecutions(executions)
+        this.getAndIncrementExecutions(executions)
       ],
     };
 
@@ -584,7 +585,7 @@ export class DRAW_Line extends DRAW_Base {
     inputObject = {
       ...inputObject,
       ...inputObject[injectedDataName][
-      this.getAndIncrementExecutions(executions)
+        this.getAndIncrementExecutions(executions)
       ],
     };
     const graphics: PIXI.Graphics = new PIXI.Graphics();
@@ -651,7 +652,7 @@ export class DRAW_Polygon extends DRAW_Base {
     inputObject = {
       ...inputObject,
       ...inputObject[injectedDataName][
-      this.getAndIncrementExecutions(executions)
+        this.getAndIncrementExecutions(executions)
       ],
     };
     const graphics: PIXI.Graphics = new PIXI.Graphics();

--- a/src/nodes/image/image.ts
+++ b/src/nodes/image/image.ts
@@ -58,7 +58,7 @@ export class Image extends PPNode {
       new Socket(
         SOCKET_TYPE.IN,
         imageResetSize,
-        new TriggerType(TRIGGER_TYPE_OPTIONS[0].value, 'resetNodeSize'),
+        new TriggerType(TRIGGER_TYPE_OPTIONS[0].text, 'resetNodeSize'),
         0,
         false
       ),

--- a/src/nodes/macro/macro.ts
+++ b/src/nodes/macro/macro.ts
@@ -177,7 +177,7 @@ export class ExecuteMacro extends CustomFunction {
     Object.values(PPGraph.currentGraph.nodes)
       .filter((node) => node instanceof Macro)
       .map((node) => {
-        return { text: node.nodeName, value: node.nodeName };
+        return { text: node.nodeName };
       });
 
   getColor(): TRgba {

--- a/src/nodes/math.ts
+++ b/src/nodes/math.ts
@@ -14,6 +14,7 @@ import { CustomFunction } from './data/dataFunctions';
 import { AbstractType } from './datatypes/abstractType';
 import * as PIXI from 'pixi.js';
 import { TextStyle } from 'pixi.js';
+
 export class MathFunction extends PPNode {
   getColor(): TRgba {
     return TRgba.fromString(NODE_TYPE_COLOR.TRANSFORM);
@@ -70,7 +71,6 @@ export class MathFunction extends PPNode {
     const mathOptions = math.map((methodName) => {
       return {
         text: methodName,
-        value: methodName,
       };
     });
 

--- a/src/nodes/state/stateNodes.ts
+++ b/src/nodes/state/stateNodes.ts
@@ -22,17 +22,17 @@ abstract class StateNode extends PPNode {
       new Socket(
         SOCKET_TYPE.IN,
         'Add',
-        new TriggerType(TRIGGER_TYPE_OPTIONS[2].value, 'add')
+        new TriggerType(TRIGGER_TYPE_OPTIONS[2].text, 'add')
       ),
       new Socket(
         SOCKET_TYPE.IN,
         'Remove',
-        new TriggerType(TRIGGER_TYPE_OPTIONS[2].value, 'remove')
+        new TriggerType(TRIGGER_TYPE_OPTIONS[2].text, 'remove')
       ),
       new Socket(
         SOCKET_TYPE.IN,
         'Clear',
-        new TriggerType(TRIGGER_TYPE_OPTIONS[2].value, 'clear')
+        new TriggerType(TRIGGER_TYPE_OPTIONS[2].text, 'clear')
       ),
       new Socket(
         SOCKET_TYPE.IN,

--- a/src/nodes/utility/playground.tsx
+++ b/src/nodes/utility/playground.tsx
@@ -54,7 +54,6 @@ export class Playground extends PPNode {
       .map((methodName) => {
         return {
           text: methodName,
-          value: methodName,
         };
       });
 
@@ -69,7 +68,6 @@ export class Playground extends PPNode {
       .map((methodName) => {
         return {
           text: methodName,
-          value: methodName,
         };
       });
 
@@ -78,25 +76,25 @@ export class Playground extends PPNode {
       new PPSocket(
         SOCKET_TYPE.IN,
         'Add all nodes',
-        new TriggerType(TRIGGER_TYPE_OPTIONS[0].value, 'addAllNodes'),
+        new TriggerType(TRIGGER_TYPE_OPTIONS[0].text, 'addAllNodes'),
         0
       ),
       new PPSocket(
         SOCKET_TYPE.IN,
         'Output graph JSON',
-        new TriggerType(TRIGGER_TYPE_OPTIONS[0].value, 'outputGraphJSON'),
+        new TriggerType(TRIGGER_TYPE_OPTIONS[0].text, 'outputGraphJSON'),
         0
       ),
       new PPSocket(
         SOCKET_TYPE.IN,
         'Output all added nodes',
-        new TriggerType(TRIGGER_TYPE_OPTIONS[0].value, 'outputAllAddedNodes'),
+        new TriggerType(TRIGGER_TYPE_OPTIONS[0].text, 'outputAllAddedNodes'),
         0
       ),
       new PPSocket(
         SOCKET_TYPE.IN,
         'Zoom to fit selected nodes',
-        new TriggerType(TRIGGER_TYPE_OPTIONS[0].value, 'zoomToFitNodes'),
+        new TriggerType(TRIGGER_TYPE_OPTIONS[0].text, 'zoomToFitNodes'),
         0
       ),
       new PPSocket(

--- a/src/nodes/utility/utility.ts
+++ b/src/nodes/utility/utility.ts
@@ -115,8 +115,10 @@ export class JumpToNode extends WidgetButton {
   }
 
   onWidgetTrigger = () => {
-    const nodeToJumpTo =
-      PPGraph.currentGraph.nodes[this.getInputData(selectNodeName)];
+    const nodeId = getNodeArrayOptions()().find(
+      (option) => option.text === this.getInputData(selectNodeName)
+    )?.value;
+    const nodeToJumpTo = PPGraph.currentGraph.nodes[nodeId];
     if (nodeToJumpTo) {
       ensureVisible([nodeToJumpTo]);
       setTimeout(() => {
@@ -168,10 +170,7 @@ export class ThrottleDebounce extends PPNode {
       new Socket(
         SOCKET_TYPE.IN,
         'Update',
-        new TriggerType(
-          TRIGGER_TYPE_OPTIONS[0].value,
-          'updateDebounceFunction'
-        ),
+        new TriggerType(TRIGGER_TYPE_OPTIONS[0].text, 'updateDebounceFunction'),
         undefined,
         false
       ),

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -211,21 +211,6 @@ function customFunctionNode(a, b) {
   return a * b;
 }`;
 
-export const PIXI_TEXT_ALIGN_OPTIONS: EnumStructure = [
-  {
-    text: 'left',
-    value: 'left',
-  },
-  {
-    text: 'center',
-    value: 'center',
-  },
-  {
-    text: 'right',
-    value: 'right',
-  },
-];
-
 export const PIXI_PIVOT_OPTIONS: EnumStructure = [
   {
     text: 'top left',
@@ -362,15 +347,12 @@ export const CONDITION_OPTIONS: EnumStructure = [
 export const TRIGGER_TYPE_OPTIONS: EnumStructure = [
   {
     text: 'positiveFlank',
-    value: 'positiveFlank',
   },
   {
     text: 'negativeFlank',
-    value: 'negativeFlank',
   },
   {
     text: 'change',
-    value: 'change',
   },
 ];
 

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -230,11 +230,11 @@ export const SelectWidget: React.FunctionComponent<SelectWidgetProps> = (
         onChange={onChange}
         disabled={props.hasLink}
       >
-        {options?.map(({ text, value }, index) => {
+        {options?.map(({ text }, index) => {
           return (
             <MenuItem
               key={index}
-              value={value ?? text}
+              value={text}
               sx={{
                 '&.Mui-selected': {
                   backgroundColor: `${Color(props.randomMainColor).negate()}`,
@@ -430,11 +430,11 @@ export const TriggerWidget: React.FunctionComponent<TriggerWidgetProps> = (
           value={triggerType}
           onChange={onChangeTriggerType}
         >
-          {TRIGGER_TYPE_OPTIONS?.map(({ text, value }, index) => {
+          {TRIGGER_TYPE_OPTIONS?.map(({ text }, index) => {
             return (
               <MenuItem
                 key={index}
-                value={value}
+                value={text}
                 sx={{
                   '&.Mui-selected': {
                     backgroundColor: `${Color(props.randomMainColor).negate()}`,


### PR DESCRIPTION
Fixed an issue with the dropdown/enumType where mainly the pivot property in the drawing nodes was not correctly selected after reload. Back in the day I was not consistent in how to handle the dropdown component and what values to use. This I have fixed and have made more consistent.
* Enum/Dropdown options should be an array of objects which have at least a `text` property. No other property is required
* Optionally you can add a `value` property in case you need a separate value. Getting the value would have to be done individually in the node itself
* However when saving, only the `text` property is stored in the socket. An optional `value` would have to be looked up

Also updated the RandomArray node as it had an old school implementation of a node trigger.