### PR TITLE
Unsaved changes warning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -194,7 +194,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
         switch (extension) {
           case 'ppgraph':
             data = await response.text();
-            await PPStorage.getInstance().loadGraphFromFile(JSON.parse(data));
+            await PPStorage.getInstance().loadGraphFromData(JSON.parse(data));
             break;
           case 'csv':
           case 'ods':
@@ -479,7 +479,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
       removeUrlParameter('loadURL');
     } else {
       if (!createEmptyGraph) {
-        PPStorage.getInstance().loadGraph();
+        PPStorage.getInstance().loadGraphFromDB();
       }
     }
 
@@ -741,7 +741,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
         // remove selection flag
         selected.isNew = undefined;
       } else {
-        PPStorage.getInstance().loadGraph(selected.id);
+        PPStorage.getInstance().loadGraphFromDB(selected.id);
       }
       setGraphSearchActiveItem(selected);
     }
@@ -977,7 +977,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
                   );
                   updateGraphSearchItems();
                   if (actionObject.id == deletedGraphID) {
-                    PPStorage.getInstance().loadGraph();
+                    PPStorage.getInstance().loadGraphFromDB();
                   }
                 }}
               >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,7 +123,6 @@ const App = (): JSX.Element => {
   const [isGraphContextMenuOpen, setIsGraphContextMenuOpen] = useState(false);
   const [isNodeContextMenuOpen, setIsNodeContextMenuOpen] = useState(false);
   const [isSocketContextMenuOpen, setIsSocketContextMenuOpen] = useState(false);
-  const [unsavedChanges, setUnsavedChanges] = useState(false);
   const [selectedSocket, setSelectedSocket] = useState<PPSocket | null>(null);
   const [contextMenuPosition, setContextMenuPosition] = useState([0, 0]);
   const [isCurrentGraphLoaded, setIsCurrentGraphLoaded] = useState(false);
@@ -195,8 +194,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
         switch (extension) {
           case 'ppgraph':
             data = await response.text();
-            await PPGraph.currentGraph.configure(JSON.parse(data), false);
-            PPStorage.getInstance().saveNewGraph(removeExtension(file.name));
+            await PPStorage.getInstance().loadGraphFromFile(JSON.parse(data));
             break;
           case 'csv':
           case 'ods':
@@ -601,19 +599,6 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
       );
     };
   }, []);
-
-  useEffect(() => {
-    const handler = (e) => {
-      e.preventDefault();
-      if (!unsavedChanges) {
-        return;
-      }
-      e.returnValue = true;
-    };
-
-    window.addEventListener('beforeunload', handler);
-    return () => window.removeEventListener('beforeunload', handler);
-  }, [unsavedChanges]);
 
   useEffect(() => {
     InterfaceController.showSnackBar = enqueueSnackbar;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,6 +123,7 @@ const App = (): JSX.Element => {
   const [isGraphContextMenuOpen, setIsGraphContextMenuOpen] = useState(false);
   const [isNodeContextMenuOpen, setIsNodeContextMenuOpen] = useState(false);
   const [isSocketContextMenuOpen, setIsSocketContextMenuOpen] = useState(false);
+  const [unsavedChanges, setUnsavedChanges] = useState(false);
   const [selectedSocket, setSelectedSocket] = useState<PPSocket | null>(null);
   const [contextMenuPosition, setContextMenuPosition] = useState([0, 0]);
   const [isCurrentGraphLoaded, setIsCurrentGraphLoaded] = useState(false);
@@ -360,9 +361,6 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     document.addEventListener('paste', pasteClipboard);
 
     window.addEventListener('mousemove', setMousePosition, false);
-    window.onbeforeunload = function () {
-      return 'You have unsaved changes!';
-    };
 
     // create viewport
     viewport.current = new Viewport({
@@ -603,6 +601,19 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
       );
     };
   }, []);
+
+  useEffect(() => {
+    const handler = (e) => {
+      e.preventDefault();
+      if (!unsavedChanges) {
+        return;
+      }
+      e.returnValue = true;
+    };
+
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [unsavedChanges]);
 
   useEffect(() => {
     InterfaceController.showSnackBar = enqueueSnackbar;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -360,6 +360,9 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     document.addEventListener('paste', pasteClipboard);
 
     window.addEventListener('mousemove', setMousePosition, false);
+    window.onbeforeunload = function () {
+      return 'You have unsaved changes!';
+    };
 
     // create viewport
     viewport.current = new Viewport({

--- a/src/PPStorage.tsx
+++ b/src/PPStorage.tsx
@@ -1,6 +1,7 @@
 import { Viewport } from 'pixi-viewport';
 import InterfaceController, { ListenEvent } from './InterfaceController';
 import { GESTUREMODE, GET_STARTED_URL } from './utils/constants';
+import { ActionHandler } from './utils/actionHandler';
 import { GraphDatabase } from './utils/indexedDB';
 import {
   downloadFile,
@@ -59,7 +60,7 @@ function detectTrackPad(event) {
 
 function checkForUnsavedChanges(): boolean {
   return (
-    !PPGraph.currentGraph.existsUnsavedChanges() ||
+    !ActionHandler.existsUnsavedChanges() ||
     window.confirm('Changes that you made may not be saved. OK to continue?')
   );
 }
@@ -295,7 +296,7 @@ export default class PPStorage {
         // load get started graph if there is no saved graph
         this.loadGraphFromURL(GET_STARTED_URL);
       }
-      PPGraph.currentGraph.setUnsavedChange(false);
+      ActionHandler.setUnsavedChange(false);
     }
   }
 
@@ -367,7 +368,7 @@ export default class PPStorage {
           console.log(`Updated currentGraph: ${indexId}`);
           InterfaceController.showSnackBar('Playground was saved');
         }
-        PPGraph.currentGraph.setUnsavedChange(false);
+        ActionHandler.setUnsavedChange(false);
       })
       .catch((e) => {
         console.log(e.stack || e);
@@ -382,7 +383,6 @@ export default class PPStorage {
     if (checkForUnsavedChanges()) {
       const nameOfFileToClone = remoteGraphsRef.current[id];
       const fileData = await this.getRemoteGraph(nameOfFileToClone);
-      console.log(fileData);
       PPGraph.currentGraph.configure(fileData);
 
       // unset loadedGraphId
@@ -402,7 +402,7 @@ export default class PPStorage {
           />
         ),
       });
-      PPGraph.currentGraph.setUnsavedChange(false);
+      ActionHandler.setUnsavedChange(false);
     }
   }
 

--- a/src/PPStorage.tsx
+++ b/src/PPStorage.tsx
@@ -27,13 +27,10 @@ const githubBranchName = 'dev';
 function SaveOrDismiss(props) {
   return (
     <>
-      <Button size="small" onClick={() => this.saveNewGraph(props.newName)}>
+      <Button size="small" onClick={props.saveClick}>
         Save
       </Button>
-      <Button
-        size="small"
-        onClick={() => InterfaceController.hideSnackBar(props.key)}
-      >
+      <Button size="small" onClick={props.dismissClick}>
         Dismiss
       </Button>
     </>
@@ -219,7 +216,12 @@ export default class PPStorage {
         InterfaceController.showSnackBar('Playground was loaded', {
           variant: 'default',
           autoHideDuration: 20000,
-          action: (key) => <SaveOrDismiss newName={newName} key={key} />,
+          action: (key) => (
+            <SaveOrDismiss
+              saveClick={() => this.saveNewGraph(newName)}
+              dismissClick={() => InterfaceController.hideSnackBar(key)}
+            />
+          ),
         });
         return fileData;
       } catch (error) {
@@ -395,7 +397,12 @@ export default class PPStorage {
       InterfaceController.showSnackBar('Remote playground was loaded', {
         variant: 'default',
         autoHideDuration: 20000,
-        action: (key) => <SaveOrDismiss newName={newName} key={key} />,
+        action: (key) => (
+          <SaveOrDismiss
+            saveClick={() => this.saveNewGraph(newName)}
+            dismissClick={() => InterfaceController.hideSnackBar(key)}
+          />
+        ),
       });
       PPGraph.currentGraph.setUnsavedChange(false);
     }

--- a/src/PPStorage.tsx
+++ b/src/PPStorage.tsx
@@ -60,9 +60,7 @@ function detectTrackPad(event) {
 function checkForUnsavedChanges(): boolean {
   return (
     !PPGraph.currentGraph.existsUnsavedChanges() ||
-    window.confirm(
-      'Changes that you made may not be saved. Do you want to continue?'
-    )
+    window.confirm('Changes that you made may not be saved. OK to continue?')
   );
 }
 

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -48,6 +48,7 @@ export default class PPGraph {
 
   tempConnection: PIXI.Graphics;
   selection: PPSelection;
+  private unsavedChanges: boolean;
 
   ticking: boolean;
 
@@ -335,6 +336,11 @@ export default class PPGraph {
     }
   }
 
+  onBeforeUnload(event: BeforeUnloadEvent): string {
+    event.preventDefault();
+    return (event.returnValue = '');
+  }
+
   // GETTERS & SETTERS
 
   set showComments(value: boolean) {
@@ -355,6 +361,24 @@ export default class PPGraph {
   }
 
   // METHODS
+
+  existsUnsavedChanges(): boolean {
+    return this.unsavedChanges;
+  }
+
+  setUnsavedChange(state: boolean): void {
+    console.log('setUnsavedChanges:', state);
+    this.unsavedChanges = state;
+    if (this.unsavedChanges) {
+      window.addEventListener('beforeunload', this.onBeforeUnload, {
+        capture: true,
+      });
+    } else {
+      window.removeEventListener('beforeunload', this.onBeforeUnload, {
+        capture: true,
+      });
+    }
+  }
 
   clearTempConnection(): void {
     this.tempConnection.clear();

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -336,11 +336,6 @@ export default class PPGraph {
     }
   }
 
-  onBeforeUnload(event: BeforeUnloadEvent): string {
-    event.preventDefault();
-    return (event.returnValue = '');
-  }
-
   // GETTERS & SETTERS
 
   set showComments(value: boolean) {
@@ -361,25 +356,6 @@ export default class PPGraph {
   }
 
   // METHODS
-
-  existsUnsavedChanges(): boolean {
-    return this.unsavedChanges;
-  }
-
-  setUnsavedChange(state: boolean): void {
-    console.log('setUnsavedChanges:', state);
-    this.unsavedChanges = state;
-    if (this.unsavedChanges) {
-      window.addEventListener('beforeunload', this.onBeforeUnload, {
-        capture: true,
-      });
-    } else {
-      window.removeEventListener('beforeunload', this.onBeforeUnload, {
-        capture: true,
-      });
-    }
-  }
-
   clearTempConnection(): void {
     this.tempConnection.clear();
     this.dragSourcePoint = undefined;

--- a/src/utils/actionHandler.tsx
+++ b/src/utils/actionHandler.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable prettier/prettier */
+import PPGraph from '../classes/GraphClass';
 
 // This can be invoked at will, any action you do that you can describe a corresponding undo action can be sent in here and handled by undohandler
 
@@ -6,41 +6,45 @@ export interface Action {
   (): Promise<void>;
 }
 interface UndoAction {
-  action : Action,
-  undo: Action,
+  action: Action;
+  undo: Action;
 }
 
 export class ActionHandler {
-  static undoList : UndoAction[] = [];
-  static redoList : UndoAction[] =  [];
+  static undoList: UndoAction[] = [];
+  static redoList: UndoAction[] = [];
 
   // if you make an action through this and pass the inverse in as undo, it becomes part of the undo/redo stack, if your code is messy and you cant describe the main action as one thing, feel free to skip inital action
-  static async performAction(action : Action, undo:Action, doPerformAction = true){
-    if (doPerformAction){
+  static async performAction(
+    action: Action,
+    undo: Action,
+    doPerformAction = true
+  ) {
+    if (doPerformAction) {
       await action();
     }
-    this.undoList.push({action:action, undo:undo});
+    this.undoList.push({ action: action, undo: undo });
+    PPGraph.currentGraph.setUnsavedChange(true);
   }
   static async undo() {
     // move top of undo stack to top of redo stack
     const lastAction = this.undoList.pop();
-    if (lastAction){
+    if (lastAction) {
       await lastAction.undo();
       this.redoList.push(lastAction);
-      console.log("undo");
-    } else{
-      console.log("Not possible to undo, nothing in undo stack");
+      console.log('undo');
+    } else {
+      console.log('Not possible to undo, nothing in undo stack');
     }
-
   }
-  static async redo(){
+  static async redo() {
     const lastUndo = this.redoList.pop();
-    if (lastUndo){
+    if (lastUndo) {
       await lastUndo.action();
       this.undoList.push(lastUndo);
-      console.log("redo");
-    } else{
-      console.log("Not possible to redo, nothing in redo stack");
+      console.log('redo');
+    } else {
+      console.log('Not possible to redo, nothing in redo stack');
     }
   }
 }


### PR DESCRIPTION
* Added an unsaved changes warning when
  * closing or reloading a tab/window -> shows standard close/reload tab browser dialog (no control over design or text)
  * loading another graph -> shows the browsers default confirmation dialog (no control over design)
    * for this case we can add a react modal dialog in the future to make it prettier

<img width="272" alt="Screenshot 2023-02-03 at 20 20 29" src="https://user-images.githubusercontent.com/4619772/216689183-0ec1294c-c31e-4231-b517-d3f17f152d24.png">
<img width="277" alt="Screenshot 2023-02-02 at 22 12 20" src="https://user-images.githubusercontent.com/4619772/216688404-301c4a9f-3dd0-4455-bf69-d2d9080654cc.png">
<img width="461" alt="Screenshot 2023-02-03 at 20 16 05" src="https://user-images.githubusercontent.com/4619772/216688406-209b262c-be4a-4cd6-90a8-363b06a663a3.png">
