### PR TITLE
Fix react crash and socket not updating right away

### DIFF
--- a/src/SocketContainer.tsx
+++ b/src/SocketContainer.tsx
@@ -42,7 +42,7 @@ export const SocketContainer: React.FunctionComponent<SocketContainerProps> = (
     data: props.data,
     randomMainColor: props.randomMainColor,
   };
-  // const widget = dataTypeValue.getInputWidget(baseProps);
+
   const widget = props.isInput
     ? dataTypeValue.getInputWidget(baseProps)
     : dataTypeValue.getOutputWidget(baseProps);
@@ -68,6 +68,10 @@ export const SocketContainer: React.FunctionComponent<SocketContainerProps> = (
       });
     }
   }, [props.triggerScrollIntoView]);
+
+  useEffect(() => {
+    setDataTypeValue(props.dataType);
+  }, [props.dataType]);
 
   return (
     <Box ref={myRef} sx={{ bgcolor: 'background.default' }}>

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -4,7 +4,7 @@ import MonacoEditor, { monaco } from 'react-monaco-editor';
 import { Box, Button } from '@mui/material';
 import ErrorFallback from './ErrorFallback';
 import { MAX_STRING_LENGTH } from '../utils/constants';
-import { getLoadedValue } from '../utils/utils';
+import { convertToString, getLoadedValue } from '../utils/utils';
 
 type CodeEditorProps = {
   value: unknown;
@@ -14,7 +14,7 @@ type CodeEditorProps = {
 };
 
 export const CodeEditor: React.FunctionComponent<CodeEditorProps> = (props) => {
-  const valueLength = String(props.value)?.length;
+  const valueLength = convertToString(props.value)?.length;
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
   const [loadAll, setLoadAll] = useState(valueLength < MAX_STRING_LENGTH);
 
@@ -24,7 +24,7 @@ export const CodeEditor: React.FunctionComponent<CodeEditorProps> = (props) => {
   const [editorHeight, setEditorHeight] = useState(48);
 
   const onLoadAll = () => {
-    setLoadedValue(String(props.value));
+    setLoadedValue(convertToString(props.value));
     setLoadAll(true);
   };
 

--- a/src/utils/actionHandler.tsx
+++ b/src/utils/actionHandler.tsx
@@ -48,7 +48,6 @@ export class ActionHandler {
   }
 
   static setUnsavedChange(state: boolean): void {
-    console.log('setUnsavedChanges:', state);
     this.graphHasUnsavedChanges = state;
     if (this.graphHasUnsavedChanges) {
       window.addEventListener('beforeunload', this.onBeforeUnload, {

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -204,6 +204,7 @@ export const SelectWidget: React.FunctionComponent<SelectWidgetProps> = (
 ) => {
   const [data, setData] = useState(props.data ?? '');
   const [options, setOptions] = useState(props.options);
+
   useInterval(() => {
     if (data !== props.property.data) {
       setData(props.property.data);
@@ -310,21 +311,23 @@ export type TextWidgetProps = {
 };
 
 export const TextWidget: React.FunctionComponent<TextWidgetProps> = (props) => {
-  const dataLength = String(props.data)?.length;
+  const dataLength = convertToString(props.data)?.length;
   const [loadAll, setLoadAll] = useState(dataLength < MAX_STRING_LENGTH);
 
   const [loadedData, setLoadedData] = useState(
-    getLoadedValue(String(props.data), loadAll)
+    getLoadedValue(convertToString(props.data), loadAll)
   );
 
   const onLoadAll = () => {
-    setLoadedData(String(props.data));
+    setLoadedData(convertToString(props.data));
     setLoadAll(true);
   };
 
   useInterval(() => {
     if (loadedData !== props.property.data) {
-      setLoadedData(getLoadedValue(String(props.property.data), loadAll));
+      setLoadedData(
+        getLoadedValue(convertToString(props.property.data), loadAll)
+      );
     }
   }, 100);
 


### PR DESCRIPTION
This PR fixes 2 different bugs
* react crash due to `String(asdf)` not being able to handle object data which does not have a toString() method
* issue where, when switching between nodes, the socket types would not update on first click


https://user-images.githubusercontent.com/4619772/217668110-95a382e9-d5f8-4b33-9294-b1b17a0f789a.mov

https://user-images.githubusercontent.com/4619772/217668111-02cb9aa9-10a8-4ffe-a45f-0c57a1639630.mov

