### PR TITLE
Fix for not removing all nodes

### DIFF
--- a/src/classes/LinkClass.ts
+++ b/src/classes/LinkClass.ts
@@ -82,7 +82,7 @@ export default class PPLink extends PIXI.Container {
     if (this.getTarget()) {
       this.getTarget().removeLink(this);
       if (!newConnectionPending) {
-        this.getTarget().getNode().executeOptimizedChain();
+        this.getTarget().getNode()?.executeOptimizedChain();
       }
     }
     this.getSource().removeLink(this);


### PR DESCRIPTION
Regarding the issue where when selecting all nodes, and deleting them, they would not be deleted in one go and raise an error in this row:
```this.getTarget().getNode().executeOptimizedChain();```

I am still not sure why this only happens sometimes, but I am pretty sure that the issue is based on the fact that the links are being deleted asynchronously after the node is being destroyed:

When deleting a node:
* the node is destroyed
* an event is emitted
* onRemoved is triggered which then removes all the links
And therefore having above in the delete function can sometimes throw an error as the node does not exist anymore and can not be updated.

```
  _onRemoved(): void {
    // remove added listener from graph.viewport
    PPGraph.currentGraph.viewport.removeListener(
      'moved',
      this.onViewportMoveHandler
    );

    this.getAllSockets().forEach((socket) => {
      socket.links.forEach((link) => link.delete());
    });

    this.onNodeRemoved();
  }
```
This function gets called after 