### PR TITLE
Adding node source and fix for label node

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ import {
   CONTEXTMENU_WIDTH,
   DRAGANDDROP_GRID_MARGIN,
   GRID_SHADER,
+  NODE_SOURCE,
   PLUGANDPLAY_ICON,
   RANDOMMAINCOLOR,
 } from './utils/constants';
@@ -788,17 +789,25 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
         let addedNode: PPNode;
         const nodeExists = getAllNodeTypes()[selected?.title] !== undefined;
         if (nodeExists) {
-          addedNode = PPGraph.currentGraph.addNewNode(selected.title, {
-            overrideId: referenceID,
-            nodePosX: nodePos.x,
-            nodePosY: nodePos.y,
-          });
+          addedNode = PPGraph.currentGraph.addNewNode(
+            selected.title,
+            {
+              overrideId: referenceID,
+              nodePosX: nodePos.x,
+              nodePosY: nodePos.y,
+            },
+            addLink ? NODE_SOURCE.NEWCONNECTED : NODE_SOURCE.NEW
+          );
         } else {
-          addedNode = PPGraph.currentGraph.addNewNode('CustomFunction', {
-            overrideId: referenceID,
-            nodePosX: nodePos.x,
-            nodePosY: nodePos.y,
-          });
+          addedNode = PPGraph.currentGraph.addNewNode(
+            'CustomFunction',
+            {
+              overrideId: referenceID,
+              nodePosX: nodePos.x,
+              nodePosY: nodePos.y,
+            },
+            addLink ? NODE_SOURCE.NEWCONNECTED : NODE_SOURCE.NEW
+          );
           addedNode.nodeName = selected.title;
         }
         if (addLink) {

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -2,13 +2,14 @@
 import * as PIXI from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
 
-import { NODE_WIDTH, PP_VERSION } from '../utils/constants';
+import { NODE_SOURCE, NODE_WIDTH, PP_VERSION } from '../utils/constants';
 import {
   CustomArgs,
   SerializedGraph,
   SerializedLink,
   SerializedNode,
   SerializedSelection,
+  TNodeSource,
 } from '../utils/interfaces';
 import { connectNodeToSocket } from '../utils/utils';
 import { getNodesBounds } from '../pixi/utils-pixi';
@@ -419,7 +420,10 @@ export default class PPGraph {
     return node;
   }
 
-  addNode<T extends PPNode = PPNode>(node: T): T {
+  addNode<T extends PPNode = PPNode>(
+    node: T,
+    source: TNodeSource = NODE_SOURCE.SERIALIZED
+  ): T {
     if (!node) {
       return;
     }
@@ -428,7 +432,7 @@ export default class PPGraph {
     this.nodes[node.id] = node;
     this.nodeContainer.addChild(node);
 
-    node.onNodeAdded();
+    node.onNodeAdded(source);
 
     return node;
   }
@@ -458,8 +462,10 @@ export default class PPGraph {
       await this.connect(outputRef, inputRef, false);
     } else {
       console.warn(
-        `Link could not be created between ${link.sourceNodeId}/${link.sourceSocketName
-        }${outputRef === undefined ? '-MISSING' : ''} and ${link.targetNodeId
+        `Link could not be created between ${link.sourceNodeId}/${
+          link.sourceSocketName
+        }${outputRef === undefined ? '-MISSING' : ''} and ${
+          link.targetNodeId
         }/${link.targetSocketName}${inputRef === undefined ? '-MISSING' : ''}`
       );
       InterfaceController.showSnackBar(
@@ -472,9 +478,13 @@ export default class PPGraph {
     }
   }
 
-  addNewNode(type: string, customArgs: CustomArgs = {}): PPNode {
+  addNewNode(
+    type: string,
+    customArgs: CustomArgs = {},
+    source: TNodeSource = NODE_SOURCE.NEW
+  ): PPNode {
     const node = this.createNode(type, customArgs);
-    this.addNode(node);
+    this.addNode(node, source);
     return node;
   }
 
@@ -653,18 +663,26 @@ export default class PPGraph {
     let newNode;
     if (socket.isInput()) {
       const nodeType = socket.dataType.defaultInputNodeWidget();
-      newNode = this.addNewNode(nodeType, {
-        nodePosX: node.x,
-        nodePosY: node.y + socket.y,
-        initialData: socket.data,
-      });
+      newNode = this.addNewNode(
+        nodeType,
+        {
+          nodePosX: node.x,
+          nodePosY: node.y + socket.y,
+          initialData: socket.data,
+        },
+        NODE_SOURCE.NEWCONNECTED
+      );
       newNode.setPosition(-(newNode.width + 40), 0, true);
     } else {
       const nodeType = socket.dataType.defaultOutputNodeWidget();
-      newNode = this.addNewNode(nodeType, {
-        nodePosX: node.x + (node.width + 40),
-        nodePosY: node.y + socket.y,
-      });
+      newNode = this.addNewNode(
+        nodeType,
+        {
+          nodePosX: node.x + (node.width + 40),
+          nodePosY: node.y + socket.y,
+        },
+        NODE_SOURCE.NEWCONNECTED
+      );
     }
     await connectNodeToSocket(socket, newNode);
   }

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -8,6 +8,7 @@ import {
   SerializedNode,
   SerializedSocket,
   TRgba,
+  TNodeSource,
   TSocketType,
 } from '../utils/interfaces';
 import {
@@ -20,6 +21,7 @@ import {
   NODE_MARGIN,
   NODE_PADDING_BOTTOM,
   NODE_PADDING_TOP,
+  NODE_SOURCE,
   NODE_TEXTSTYLE,
   NODE_WIDTH,
   SOCKET_HEIGHT,
@@ -79,29 +81,30 @@ export default class PPNode extends PIXI.Container {
   protected statuses: NodeStatus[] = []; // you can add statuses into this and they will be rendered on the node
 
   // supported callbacks
-  onConfigure: (nodeConfig: SerializedNode) => void = () => { }; // called after the node has been configured
-  onNodeDoubleClick: (event: PIXI.InteractionEvent) => void = () => { };
-  onViewportMoveHandler: (event?: PIXI.InteractionEvent) => void = () => { };
+  onConfigure: (nodeConfig: SerializedNode) => void = () => {}; // called after the node has been configured
+  onNodeDoubleClick: (event: PIXI.InteractionEvent) => void = () => {};
+  onViewportMoveHandler: (event?: PIXI.InteractionEvent) => void = () => {};
   onViewportPointerUpHandler: (event?: PIXI.InteractionEvent) => void =
-    () => { };
-  onNodeRemoved: () => void = () => { }; // called when the node is removed from the graph
-  onNodeResize: (width: number, height: number) => void = () => { }; // called when the node is resized
+    () => {};
+  onNodeRemoved: () => void = () => {}; // called when the node is removed from the graph
+  onNodeResize: (width: number, height: number) => void = () => {}; // called when the node is resized
   onNodeDragOrViewportMove: // called when the node or or the viewport with the node is moved or scaled
-    (positions: { screenX: number; screenY: number; scale: number }) => void =
-    () => { };
+  (positions: { screenX: number; screenY: number; scale: number }) => void =
+    () => {};
 
   // called when the node is added to the graph
-  public onNodeAdded(): void {
+  public onNodeAdded(source: TNodeSource = NODE_SOURCE.SERIALIZED): void {
     if (this.executeOnPlace()) {
       this.executeOptimizedChain();
     }
     this.resizeAndDraw(this.getDefaultNodeWidth(), this.getDefaultNodeHeight());
   }
+
   public executeOnPlace(): boolean {
     return false;
   }
 
-  protected onNodeExit(): void { }
+  protected onNodeExit(): void {}
 
   ////////////////////////////// Meant to be overriden for visual/behavioral needs
 
@@ -191,7 +194,7 @@ export default class PPNode extends PIXI.Container {
   }
   // used when searching for nodes
   public getTags(): string {
-    return "";
+    return '';
   }
 
   public getMinNodeWidth(): number {
@@ -480,7 +483,10 @@ export default class PPNode extends PIXI.Container {
     );
     try {
       const mapSocket = (item: SerializedSocket) => {
-        const matchingSocket = this.getSocketByNameAndType(item.name, item.socketType);
+        const matchingSocket = this.getSocketByNameAndType(
+          item.name,
+          item.socketType
+        );
         if (matchingSocket !== undefined) {
           matchingSocket.dataType = deSerializeType(item.dataType);
           this.initializeType(item.name, matchingSocket.dataType);
@@ -725,8 +731,7 @@ export default class PPNode extends PIXI.Container {
           this.headerHeight +
           this.countOfVisibleNodeTriggerSockets * SOCKET_HEIGHT +
           (!this.getParallelInputsOutputs()
-            ?
-            this.countOfVisibleOutputSockets * SOCKET_HEIGHT
+            ? this.countOfVisibleOutputSockets * SOCKET_HEIGHT
             : 0) +
           index * SOCKET_HEIGHT;
         item.showLabel = this.getShowLabels();
@@ -737,7 +742,6 @@ export default class PPNode extends PIXI.Container {
   protected drawStatuses(): void {
     this._StatusesRef.clear();
     this._StatusesRef.removeChildren();
-
 
     this.statuses.forEach((nStatus, index) => {
       const color = nStatus.color;
@@ -755,21 +759,19 @@ export default class PPNode extends PIXI.Container {
           fill: COLOR_MAIN,
         })
       );
-      text.x = this.nodeWidth - inlet + 5;// - width;
+      text.x = this.nodeWidth - inlet + 5; // - width;
       text.y = startY + 5 + index * (height - merging);
       this._StatusesRef.addChild(text);
       this._StatusesRef.beginFill(color.hexNumber());
       this._StatusesRef.drawRoundedRect(
-        this.nodeWidth - inlet,// - width,
+        this.nodeWidth - inlet, // - width,
         startY + index * (height - merging),
         text.width + 10,
         height,
         NODE_CORNERRADIUS
       );
     });
-
   }
-
 
   public drawNodeShape(): void {
     // update selection
@@ -785,7 +787,6 @@ export default class PPNode extends PIXI.Container {
     this.drawComment();
     this.drawStatuses();
   }
-
 
   constructSocketName(prefix: string, existing: Socket[]): string {
     let count = 1;
@@ -920,7 +921,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     if (
       this.updateBehaviour.interval &&
       currentTime - this.lastTimeTicked >=
-      this.updateBehaviour.intervalFrequency
+        this.updateBehaviour.intervalFrequency
     ) {
       this.lastTimeTicked = currentTime;
       this.executeOptimizedChain();
@@ -1177,5 +1178,5 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
   }
 
   // kinda hacky but some cant easily serialize functions in JS
-  protected initializeType(socketName: string, datatype: any) { }
+  protected initializeType(socketName: string, datatype: any) {}
 }

--- a/src/nodes/text.tsx
+++ b/src/nodes/text.tsx
@@ -2,9 +2,10 @@ import * as PIXI from 'pixi.js';
 import PPGraph from '../classes/GraphClass';
 import PPNode from '../classes/NodeClass';
 import PPSocket from '../classes/SocketClass';
-import { CustomArgs, TRgba } from '../utils/interfaces';
+import { CustomArgs, TNodeSource, TRgba } from '../utils/interfaces';
 import {
   NODE_MARGIN,
+  NODE_SOURCE,
   NODE_TYPE_COLOR,
   NOTE_LINEHEIGHT_FACTOR,
   NOTE_MARGIN_STRING,
@@ -97,20 +98,20 @@ export class Label extends PPNode {
     return this.getInputData('backgroundColor');
   }
 
-  // when the Node is added, focus it so one can start writing
-  public onNodeAdded = () => {
+  public onNodeAdded = (source?: TNodeSource) => {
     if (this.initialData) {
       this.setInputData('Input', this.initialData);
     }
-    this.currentInput = null;
-    this.createInputElement();
-    super.onNodeAdded();
-  };
 
-  // when the Node has been configured, remove focus
-  public onConfigure = () => {
-    this.currentInput.remove();
-    this._refText.visible = true;
+    // if the Node is newly added, focus it so one can start writing
+    if (source === NODE_SOURCE.NEW) {
+      this.currentInput = null;
+      this.createInputElement();
+    } else {
+      this._refText.visible = true;
+    }
+
+    super.onNodeAdded(source);
   };
 
   public createInputElement = () => {

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -174,6 +174,12 @@ export const NODE_TYPE_COLOR = {
   MISSING: COLOR_ERROR,
 };
 
+export const NODE_SOURCE = {
+  NEW: 'New',
+  NEWCONNECTED: 'NewConnected',
+  SERIALIZED: 'Serialized',
+} as const;
+
 export const COMMENT_TEXTSTYLE = new TextStyle({
   fontSize: 12,
   fill: COLOR_COMMENT,

--- a/src/utils/interfaces.tsx
+++ b/src/utils/interfaces.tsx
@@ -1,7 +1,7 @@
 import * as PIXI from 'pixi.js';
 import PPNode from '../classes/NodeClass';
 import { IUpdateBehaviour } from '../classes/UpdateBehaviourClass';
-import { COLOR_DARK, COLOR_WHITE, SOCKET_TYPE } from './constants';
+import { COLOR_DARK, COLOR_WHITE, SOCKET_TYPE, NODE_SOURCE } from './constants';
 import Color from 'color';
 
 export type RegisteredNodeTypes = Record<
@@ -103,6 +103,8 @@ export type NodeStatus = {
   color: TRgba;
   statusText: string;
 };
+
+export type TNodeSource = (typeof NODE_SOURCE)[keyof typeof NODE_SOURCE];
 
 export class TRgba {
   r = 0;


### PR DESCRIPTION
This is a suggestion for what I called "node source", where serialized is the common one for loaded and pasted. I don't think we have to differentiate between them.
This PR also fixes the issue with the label node. It works even better now as it does not focus anymore when adding a new connected label.
```
export const NODE_SOURCE = {
  NEW: 'New',
  NEWCONNECTED: 'NewConnected',
  SERIALIZED: 'Serialized',
} as const;
```