### PR TITLE
Fixes issue where trigger would not execute after loading

### DIFF
--- a/src/nodes/datatypes/triggerType.tsx
+++ b/src/nodes/datatypes/triggerType.tsx
@@ -7,7 +7,7 @@ import { TRIGGER_TYPE_OPTIONS } from '../../utils/constants';
 export class TriggerType extends AbstractType {
   triggerType: string;
   customFunctionString: string;
-  previousData: any = null;
+  previousData: any = undefined;
   constructor(
     triggerType = TRIGGER_TYPE_OPTIONS[0].text,
     customFunctionString = ''
@@ -42,12 +42,14 @@ export class TriggerType extends AbstractType {
     super.onDataSet(data, socket);
     if (
       socket.isInput() &&
-      ((this.triggerType === TRIGGER_TYPE_OPTIONS[0].text &&
-        this.previousData < data) ||
+      (this.previousData === undefined || // after loading the first time, execute regardless
+        (this.triggerType === TRIGGER_TYPE_OPTIONS[0].text &&
+          this.previousData < data) ||
         (this.triggerType === TRIGGER_TYPE_OPTIONS[1].text &&
           this.previousData > data) ||
         (this.triggerType === TRIGGER_TYPE_OPTIONS[2].text &&
-          this.previousData !== data) || this.triggerType === TRIGGER_TYPE_OPTIONS[3].text)
+          this.previousData !== data) ||
+        this.triggerType === TRIGGER_TYPE_OPTIONS[3].text)
     ) {
       // if im an input and condition is fullfilled, execute either custom function or start new chain with this as origin
       if (this.customFunctionString !== '') {


### PR DESCRIPTION
This fixes an issue where a trigger button, when using positive or negative flank, would not execute the first time after loading. In our welcome graph for example, you have to always click twice the first to open a URL.
This is due to the previousData being initially undefined and undefined > x or x < undefined is always false.

<img width="473" alt="Screenshot 2023-05-07 at 17 04 32" src="https://user-images.githubusercontent.com/4619772/236685591-d9534af6-1e9c-4ca6-8967-8d145b2cb63e.png">

<img width="312" alt="Screenshot 2023-05-07 at 17 00 32" src="https://user-images.githubusercontent.com/4619772/236685396-79795da4-f014-408b-86b8-e04ef97e3cfa.png">
