### PR TITLE
Fix replace node issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -806,21 +806,27 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
         const serializedNode = oldNode.serialize();
 
         const action = async () => {
-          PPGraph.currentGraph.replaceNode(
+          const newNode = PPGraph.currentGraph.replaceNode(
             serializedNode,
             serializedNode.id,
             referenceID,
             newNodeType
           );
+          InterfaceController.notifyListeners(ListenEvent.SelectionChanged, [
+            newNode,
+          ]);
           setActiveItemArray();
           setIsNodeSearchVisible(false);
         };
         const undoAction = async () => {
-          PPGraph.currentGraph.replaceNode(
+          const previousNode = PPGraph.currentGraph.replaceNode(
             serializedNode,
             referenceID,
             serializedNode.id
           );
+          InterfaceController.notifyListeners(ListenEvent.SelectionChanged, [
+            previousNode,
+          ]);
         };
         await ActionHandler.performAction(action, undoAction);
       } else {

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -537,7 +537,7 @@ export default class PPGraph {
     newType?: string,
     newSerializedNode?: SerializedNode,
     notify?: boolean
-  ) => {
+  ): PPNode => {
     const newNode = this.addSerializedNode(
       newSerializedNode ?? oldSerializedNode,
       {
@@ -553,6 +553,8 @@ export default class PPGraph {
     this.selection.selectNodes([newNode], false, notify);
     this.selection.drawRectanglesFromSelection();
     this.removeNode(this.nodes[oldId]);
+
+    return newNode;
   };
 
   async linkConnect(

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import PPStorage from '../PPStorage';
 
 function ErrorFallback({ error, resetErrorBoundary }) {
   return (
     <div role="alert" style={{ color: 'white' }}>
       <p>Something went wrong:</p>
       <pre>{error.message}</pre>
+      <button onClick={() => PPStorage.getInstance().saveNewGraph()}>
+        Save a backup
+      </button>
       <button onClick={resetErrorBoundary}>Try again</button>
     </div>
   );


### PR DESCRIPTION
* Fixes a crash when replacing a node and clicking on one of the sockets right away. It looks for the old selection which was not updated
* I also added a "save as/save backup" button on the react error screen. Even though the graph could end up being broken, this might still be better than reloading and losing all the unsaved work