### PR TITLE
fix trigger type issue

### DIFF
--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -656,7 +656,10 @@ export default class PPGraph {
     input.links = [link];
 
     // set input data from output data, if undefined use socket type default value
-    input.data = output.data || output.dataType.getDefaultValue();
+    input.data =
+      output.data === undefined
+        ? output.dataType.getDefaultValue()
+        : output.data;
 
     this.connectionContainer.addChild(link);
 

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -655,7 +655,8 @@ export default class PPGraph {
     //add link to input
     input.links = [link];
 
-    input.data = output.data;
+    // set input data from output data, if undefined use socket type default value
+    input.data = output.data || output.dataType.getDefaultValue();
 
     this.connectionContainer.addChild(link);
 

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -1088,7 +1088,6 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     return true;
   }
 
-
   public allowResize(): boolean {
     return true;
   }

--- a/src/classes/SocketClass.ts
+++ b/src/classes/SocketClass.ts
@@ -59,7 +59,7 @@ export default class Socket extends PIXI.Container {
 
     if (socketType !== SOCKET_TYPE.OUT) {
       // define defaultData for different types
-      if (data === null && dataType) {
+      if (data == null && dataType) {
         data = dataType.getDefaultValue();
       }
     }

--- a/src/nodes/datatypes/triggerType.tsx
+++ b/src/nodes/datatypes/triggerType.tsx
@@ -21,6 +21,10 @@ export class TriggerType extends AbstractType {
     return 'Trigger';
   }
 
+  getDefaultValue(): any {
+    return 0;
+  }
+
   getInputWidget = (props: any): any => {
     const triggerProps: TriggerWidgetProps = {
       property: props.property,
@@ -42,9 +46,8 @@ export class TriggerType extends AbstractType {
     super.onDataSet(data, socket);
     if (
       socket.isInput() &&
-      (this.previousData === undefined || // after loading the first time, execute regardless
-        (this.triggerType === TRIGGER_TYPE_OPTIONS[0].text &&
-          this.previousData < data) ||
+      ((this.triggerType === TRIGGER_TYPE_OPTIONS[0].text &&
+        this.previousData < data) ||
         (this.triggerType === TRIGGER_TYPE_OPTIONS[1].text &&
           this.previousData > data) ||
         (this.triggerType === TRIGGER_TYPE_OPTIONS[2].text &&


### PR DESCRIPTION
There was always an issue with the trigger type where
* it would either trigger only after the second click (because the first one did a comparison with undefined)
* or it would execute right away on load

My previous fixes where not really helping. So what I did now is:
* on connection to a any socket the default value of the output is chosen, if the output data is undefined
* make using the defaultValue for socket inputs a loose comparison
* triggerType has gotten a default value (0)
* removed the old "fix"
