### PR TITLE
Fix trigger socket disconnect issue

### DIFF
--- a/src/classes/SocketClass.ts
+++ b/src/classes/SocketClass.ts
@@ -78,7 +78,6 @@ export default class Socket extends PIXI.Container {
 
     this.addEventListener('pointerover', this.onPointerOver.bind(this));
     this.addEventListener('pointerout', this.onPointerOut.bind(this));
-    this.addEventListener('pointerdown', this.onPointerDown);
     this.addEventListener('pointerup', this.onPointerUp);
 
     this.redrawAnythingChanging();
@@ -162,6 +161,10 @@ export default class Socket extends PIXI.Container {
     this._SocketRef.endFill();
     this._SocketRef.name = 'SocketRef';
     this._SocketRef.eventMode = 'static';
+    this._SocketRef.addEventListener(
+      'pointerdown',
+      this.onSocketRefPointerDown.bind(this)
+    );
 
     this.addChild(this._SelectionBox);
     this.addChild(this._SocketRef);
@@ -411,13 +414,12 @@ export default class Socket extends PIXI.Container {
     this.getGraph().socketHoverOut(this);
   }
 
-  onPointerDown(event: PIXI.FederatedPointerEvent): void {
+  onSocketRefPointerDown(event: PIXI.FederatedPointerEvent): void {
     this.getGraph().socketMouseDown(this, event);
   }
 
   onPointerUp(event: PIXI.FederatedPointerEvent): void {
     this.getGraph().socketMouseUp(this, event);
-    //this.nodeHoveredOut(); // i removed this, is it needed?
   }
 
   socketNameRefMouseDown(event: PIXI.FederatedPointerEvent): void {


### PR DESCRIPTION
* Before, you could click on the socket rect as well as the text to re/disconnect. This interfered with the text clicking which opens the inspector on the right.
* Now, I have limited this to clicking on the socket rect, which also solves this - https://trello.com/c/57zuqE4F

In very rare cases, I have still observed that just clicking on a socket rect, could reconnect it. But I was not able to reproduce it