### PR TITLE
add width to label

### DIFF
--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -490,9 +490,9 @@ export default class PPNode extends PIXI.Container {
     const newNodeWidth = Math.max(width, this.getMinNodeWidth());
     const newNodeHeight = Math.max(height, this.getMinNodeHeight());
 
-    const oldWidth = this.nodeWidth;
-    const oldHeight = this.nodeHeight;
     if (maintainAspectRatio) {
+      const oldWidth = this.nodeWidth;
+      const oldHeight = this.nodeHeight;
       const newRect = calculateAspectRatioFit(
         oldWidth,
         oldHeight,
@@ -515,9 +515,7 @@ export default class PPNode extends PIXI.Container {
 
     this.nodeSelectionHeader.x = NODE_MARGIN + this.nodeWidth - 96;
 
-    if (oldWidth !== newNodeWidth || oldHeight !== newNodeHeight) {
-      this.onNodeResize(newNodeWidth, newNodeHeight);
-    }
+    this.onNodeResize(newNodeWidth, newNodeHeight);
 
     if (this.selected) {
       PPGraph.currentGraph.selection.drawRectanglesFromSelection();

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -85,11 +85,7 @@ export default class PPNode extends PIXI.Container {
   onViewportPointerUpHandler: (event?: PIXI.FederatedPointerEvent) => void =
     () => {};
   onNodeRemoved: () => void = () => {}; // called when the node is removed from the graph
-  onNodeResize: (
-    width: number,
-    height: number,
-    activeRescaling: boolean
-  ) => void = () => {}; // called when the node is resized
+  onNodeResize: (width: number, height: number) => void = () => {}; // called when the node is resized
   onNodeDragOrViewportMove: // called when the node or or the viewport with the node is moved or scaled
   (positions: { screenX: number; screenY: number; scale: number }) => void =
     () => {};
@@ -477,11 +473,18 @@ export default class PPNode extends PIXI.Container {
     this.refreshNodeDragOrViewportMove();
   }
 
+  onBeingScaled(
+    width: number = this.nodeWidth,
+    height: number = this.nodeHeight,
+    maintainAspectRatio = false
+  ): void {
+    this.resizeAndDraw(width, height, maintainAspectRatio);
+  }
+
   resizeAndDraw(
     width: number = this.nodeWidth,
     height: number = this.nodeHeight,
-    maintainAspectRatio = false,
-    activeRescaling = false // mouse rescaleing
+    maintainAspectRatio = false
   ): void {
     // set new size
     const newNodeWidth = Math.max(width, this.getMinNodeWidth());
@@ -513,7 +516,7 @@ export default class PPNode extends PIXI.Container {
     this.nodeSelectionHeader.x = NODE_MARGIN + this.nodeWidth - 96;
 
     if (oldWidth !== newNodeWidth || oldHeight !== newNodeHeight) {
-      this.onNodeResize(newNodeWidth, newNodeHeight, activeRescaling);
+      this.onNodeResize(newNodeWidth, newNodeHeight);
     }
 
     if (this.selected) {

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -515,7 +515,7 @@ export default class PPNode extends PIXI.Container {
 
     this.nodeSelectionHeader.x = NODE_MARGIN + this.nodeWidth - 96;
 
-    this.onNodeResize(newNodeWidth, newNodeHeight);
+    this.onNodeResize(this.nodeWidth, this.nodeHeight);
 
     if (this.selected) {
       PPGraph.currentGraph.selection.drawRectanglesFromSelection();

--- a/src/classes/SelectionClass.ts
+++ b/src/classes/SelectionClass.ts
@@ -102,7 +102,8 @@ export default class PPSelection extends PIXI.Container {
     this.selectedNodes[0].resizeAndDraw(
       Math.abs(worldPosition.x - this.selectedNodes[0].x),
       Math.abs(worldPosition.y - this.selectedNodes[0].y),
-      shiftKeyPressed
+      shiftKeyPressed,
+      true
     );
     this.drawRectanglesFromSelection();
   };

--- a/src/classes/SelectionClass.ts
+++ b/src/classes/SelectionClass.ts
@@ -99,11 +99,10 @@ export default class PPSelection extends PIXI.Container {
       pointerPosition.y
     );
 
-    this.selectedNodes[0].resizeAndDraw(
+    this.selectedNodes[0].onBeingScaled(
       Math.abs(worldPosition.x - this.selectedNodes[0].x),
       Math.abs(worldPosition.y - this.selectedNodes[0].y),
-      shiftKeyPressed,
-      true
+      shiftKeyPressed
     );
     this.drawRectanglesFromSelection();
   };

--- a/src/nodes/text.tsx
+++ b/src/nodes/text.tsx
@@ -217,12 +217,10 @@ export class Label extends PPNode {
     return textMetrics;
   };
 
-  public onNodeResize = (newWidth, newHeight, activeRescaling) => {
-    if (activeRescaling) {
-      const innerWidth = newWidth - this.getMarginLeftRight() * 2;
-      this.setInputData(widthSocketName, innerWidth);
-      this.measureThenResizeAndDrawLabel(this.getInputData(inputSocketName));
-    }
+  public onBeingScaled = (newWidth) => {
+    const innerWidth = newWidth - this.getMarginLeftRight() * 2;
+    this.setInputData(widthSocketName, innerWidth);
+    this.measureThenResizeAndDrawLabel(this.getInputData(inputSocketName));
   };
 
   public resetSize(): void {

--- a/src/nodes/text.tsx
+++ b/src/nodes/text.tsx
@@ -280,7 +280,10 @@ export class Label extends PPNode {
 
       const textMetrics = this.measureThenResizeAndDrawLabel(text);
 
-      this.HTMLTextComponent.style.width = `${textMetrics.width}px`;
+      this.HTMLTextComponent.style.width = `${Math.max(
+        20, // a small minimum width so the blinking cursor is visible
+        textMetrics.width
+      )}px`;
       this.HTMLTextComponent.style.height = `${textMetrics.height}px`;
 
       const id = this.id;

--- a/src/nodes/text.tsx
+++ b/src/nodes/text.tsx
@@ -19,7 +19,9 @@ const backgroundColorName = 'backgroundColor';
 const inputSocketName = 'Input';
 const outputSocketName = 'Output';
 const fontSizeSocketName = 'fontSize';
+const widthSocketName = 'Width';
 const labelDefaultText = '';
+const defaultNodeWidth = 128;
 
 export class Label extends PPNode {
   PIXIText: PIXI.Text;
@@ -35,6 +37,7 @@ export class Label extends PPNode {
     this.initialData = customArgs?.initialData;
 
     this.PIXITextStyle = new PIXI.TextStyle();
+    this.PIXITextStyle.breakWords = true;
     const basicText = new PIXI.Text(labelDefaultText, this.PIXITextStyle);
     this.PIXIText = this.addChild(basicText);
     this.PIXIVisible();
@@ -53,7 +56,7 @@ export class Label extends PPNode {
   }
 
   public getDefaultNodeWidth(): number {
-    return 128;
+    return defaultNodeWidth;
   }
 
   public getIsPresentationalNode(): boolean {
@@ -94,6 +97,13 @@ export class Label extends PPNode {
       ),
       new PPSocket(
         SOCKET_TYPE.IN,
+        widthSocketName,
+        new NumberType(true, 0, defaultNodeWidth * 10),
+        undefined,
+        false
+      ),
+      new PPSocket(
+        SOCKET_TYPE.IN,
         backgroundColorName,
         new ColorType(),
         TRgba.fromString(fillColor),
@@ -119,8 +129,9 @@ export class Label extends PPNode {
   public HTMLVisible() {
     this.PIXIText.visible = false;
     this.createInputElement();
-    //this.HTMLTextComponent.hidden = false;
     this.HTMLTextComponent.focus();
+    // correct initial edit view
+    this.HTMLTextComponent.dispatchEvent(new Event('input'));
   }
   public PIXIVisible() {
     this.PIXIText.visible = true;
@@ -130,14 +141,13 @@ export class Label extends PPNode {
     this.executeOptimizedChain();
   }
 
-  onPointerClick(event: PIXI.FederatedPointerEvent): void {
+  onPointerClick(): void {
     this.HTMLVisible();
   }
 
   protected async onExecute(input, output): Promise<void> {
     const text = String(input[inputSocketName]);
     const fontSize = Math.max(1, input[fontSizeSocketName]);
-    //const minWidth = Math.max(1, input['min-width']);
     const color: TRgba = input[backgroundColorName];
 
     this.PIXITextStyle.fontSize = fontSize;
@@ -146,15 +156,8 @@ export class Label extends PPNode {
       ? TRgba.white().hex()
       : TRgba.black().hex();
 
-    const textMetrics = PIXI.TextMetrics.measureText(text, this.PIXITextStyle);
+    this.measureThenResizeAndDrawLabel(text);
 
-    this.resizeAndDraw(
-      Math.max(
-        this.getMinNodeWidth(),
-        textMetrics.width + this.getMarginLeftRight() * 2
-      ),
-      textMetrics.height + this.getMarginTopBottom() * 2
-    );
     output[outputSocketName] = text;
 
     this.PIXIText.text = text;
@@ -179,8 +182,57 @@ export class Label extends PPNode {
     return this.y + this.getMarginTopBottom() + 1; // magic number 💀
   }
 
+  private getInputWidth(): number {
+    return Math.max(this.getMinNodeWidth(), this.getInputData(widthSocketName));
+  }
+
+  private useInputWidth(): boolean {
+    return Boolean(this.getInputData(widthSocketName));
+  }
+
+  private setPixiTextStyleWidth(): void {
+    if (this.useInputWidth()) {
+      this.PIXITextStyle.wordWrap = true;
+      this.PIXITextStyle.wordWrapWidth = this.getInputWidth();
+    } else {
+      this.PIXITextStyle.wordWrap = false;
+    }
+  }
+
+  private resizeAndDrawLabel(width, height): void {
+    this.resizeAndDraw(
+      Math.max(
+        this.getMinNodeWidth(),
+        (this.useInputWidth() ? this.getInputWidth() : width) +
+          this.getMarginLeftRight() * 2
+      ),
+      height + this.getMarginTopBottom() * 2
+    );
+  }
+
+  private measureThenResizeAndDrawLabel = (text) => {
+    this.setPixiTextStyleWidth();
+    const textMetrics = PIXI.TextMetrics.measureText(text, this.PIXITextStyle);
+    this.resizeAndDrawLabel(textMetrics.width, textMetrics.height);
+    return textMetrics;
+  };
+
+  public onNodeResize = (newWidth, newHeight, activeRescaling) => {
+    if (activeRescaling) {
+      const innerWidth = newWidth - this.getMarginLeftRight() * 2;
+      this.setInputData(widthSocketName, innerWidth);
+      this.measureThenResizeAndDrawLabel(this.getInputData(inputSocketName));
+    }
+  };
+
+  public resetSize(): void {
+    this.setInputData(widthSocketName, 0);
+    this.measureThenResizeAndDrawLabel(this.getInputData(inputSocketName));
+  }
+
   public createInputElement = () => {
     // create html input element
+    const htmlComponentId = `Label-${inputSocketName}`;
     const text = this.getInputData(inputSocketName);
     const fontSize = this.getInputData(fontSizeSocketName);
     const color = this.getInputData(backgroundColorName);
@@ -189,15 +241,20 @@ export class Label extends PPNode {
       this.getHTMLComponentTop()
     );
 
+    const existingElement = document.getElementById(
+      htmlComponentId
+    ) as HTMLDivElement;
+
     this.HTMLTextComponent = document.createElement('div');
-    this.HTMLTextComponent.id = inputSocketName;
+    this.HTMLTextComponent.id = htmlComponentId;
     this.HTMLTextComponent.contentEditable = 'true';
     this.HTMLTextComponent.innerText = text;
 
     const style = {
       fontFamily: 'Arial',
       fontSize: `${fontSize}px`,
-      lineHeight: `${fontSize * (NOTE_LINEHEIGHT_FACTOR + 0.025)}px`, // corrects difference between div and PIXI.Text
+      lineHeight: `${fontSize * NOTE_LINEHEIGHT_FACTOR}px`,
+      letterSpacing: '0px',
       textAlign: 'left',
       color: color.isDark() ? TRgba.white().hex() : TRgba.black().hex(),
       position: 'absolute',
@@ -210,6 +267,7 @@ export class Label extends PPNode {
       top: `${screenPoint.y}px`,
       width: `${this.nodeWidth}px`,
       height: `${this.nodeHeight}px`,
+      overflowWrap: 'anywhere',
     };
     Object.assign(this.HTMLTextComponent.style, style);
 
@@ -221,25 +279,11 @@ export class Label extends PPNode {
     this.HTMLTextComponent.addEventListener('input', (e) => {
       const text = (e as any).target.innerText;
       this.PIXIText.text = text;
-      const minWidth = this.width;
-      const textMetrics = PIXI.TextMetrics.measureText(
-        text,
-        this.PIXITextStyle
-      );
 
-      const textMetricsHeight = textMetrics.height;
+      const textMetrics = this.measureThenResizeAndDrawLabel(text);
 
-      const newWidth = textMetrics.width + this.getMarginLeftRight() * 2;
-      const newHeight = textMetricsHeight * NOTE_LINEHEIGHT_FACTOR;
-      this.HTMLTextComponent.style.width = `${newWidth}px`;
-      this.HTMLTextComponent.style.height = `${
-        newHeight + this.getMarginTopBottom() * 2
-      }px`;
-
-      this.resizeAndDraw(
-        Math.max(minWidth, newWidth),
-        newHeight + this.getMarginTopBottom()
-      );
+      this.HTMLTextComponent.style.width = `${textMetrics.width}px`;
+      this.HTMLTextComponent.style.height = `${textMetrics.height}px`;
 
       const id = this.id;
       const applyFunction = (newText) => {
@@ -256,7 +300,11 @@ export class Label extends PPNode {
       );
     });
 
-    document.body.appendChild(this.HTMLTextComponent);
+    if (existingElement) {
+      existingElement.replaceWith(this.HTMLTextComponent);
+    } else {
+      document.body.appendChild(this.HTMLTextComponent);
+    }
   };
 
   // scale input if node is scaled

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -362,7 +362,7 @@ export const getNodeDataFromText = (text: string): SerializedSelection => {
 
 export const isEventComongFromWithinWidget = (event: any): boolean => {
   return (
-    event.target.id === 'Input' ||
+    (event.target.id as string).endsWith('Input') ||
     event.target.localName === 'input' ||
     isEventComingFromWithinTextInput(event)
   );


### PR DESCRIPTION
* Added width to the label
  * 0 or undefined is no width (as wide as text)
  * you can change the width input or resize the node
  * double clicking the resize icon, resets the width to 0
* Added `activeRescaling` parameter in `onNodeResize` to differentiate between actively rescaling with mouse or just calling it from somewhere else
* `onNodeResize` is now only called if the size has changed
* fixed a bug where a new HTMLTextComponent was appended every time one edited the text
  * now all Labels share one single Label-Input div for editing text

https://github.com/fakob/plug-and-play/assets/4619772/4b022a74-447d-4e4f-8064-326a263f0e40

