### PR TITLE
Fix replace issue keeping old data

### DIFF
--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -468,7 +468,7 @@ export default class PPGraph {
   ): Promise<PPNode> {
     const node = this.createNode(newNodeType ?? serialized.type, customArgs);
 
-    node.configure(serialized);
+    node.configure(serialized, newNodeType === undefined);
     await this.addNode(node);
     return node;
   }

--- a/src/classes/NodeClass.ts
+++ b/src/classes/NodeClass.ts
@@ -371,7 +371,7 @@ export default class PPNode extends PIXI.Container {
     return node;
   }
 
-  configure(nodeConfig: SerializedNode): void {
+  configure(nodeConfig: SerializedNode, includeSocketData = true): void {
     this.x = nodeConfig.x;
     this.y = nodeConfig.y;
     this.nodeWidth = nodeConfig.width || this.getMinNodeWidth();
@@ -382,42 +382,44 @@ export default class PPNode extends PIXI.Container {
       nodeConfig.updateBehaviour.interval,
       nodeConfig.updateBehaviour.intervalFrequency
     );
-    try {
-      const mapSocket = (item: SerializedSocket) => {
-        const matchingSocket = this.getSocketByNameAndType(
-          item.name,
-          item.socketType
-        );
-        if (matchingSocket !== undefined) {
-          matchingSocket.dataType = deSerializeType(item.dataType);
-          this.initializeType(item.name, matchingSocket.dataType);
-          matchingSocket.data = item.data;
-          matchingSocket.defaultData = item.defaultData ?? item.data;
-          matchingSocket.setVisible(item.visible);
-        } else {
-          // add socket if it does not exist yet
-          console.info(
-            `Socket does not exist (yet) and will be created: ${this.name}(${this.id})/${item.name}`
+    if (includeSocketData) {
+      try {
+        const mapSocket = (item: SerializedSocket) => {
+          const matchingSocket = this.getSocketByNameAndType(
+            item.name,
+            item.socketType
           );
-          this.addSocket(
-            new Socket(
-              item.socketType,
-              item.name,
-              deSerializeType(item.dataType),
-              item.data,
-              item.visible
-            )
-          );
-        }
-      };
+          if (matchingSocket !== undefined) {
+            matchingSocket.dataType = deSerializeType(item.dataType);
+            this.initializeType(item.name, matchingSocket.dataType);
+            matchingSocket.data = item.data;
+            matchingSocket.defaultData = item.defaultData ?? item.data;
+            matchingSocket.setVisible(item.visible);
+          } else {
+            // add socket if it does not exist yet
+            console.info(
+              `Socket does not exist (yet) and will be created: ${this.name}(${this.id})/${item.name}`
+            );
+            this.addSocket(
+              new Socket(
+                item.socketType,
+                item.name,
+                deSerializeType(item.dataType),
+                item.data,
+                item.visible
+              )
+            );
+          }
+        };
 
-      const sockets = nodeConfig.socketArray;
-      sockets.forEach((item) => mapSocket(item));
-    } catch (error) {
-      console.error(
-        `Could not configure node: ${this.name}(${this.id})`,
-        error
-      );
+        const sockets = nodeConfig.socketArray;
+        sockets.forEach((item) => mapSocket(item));
+      } catch (error) {
+        console.error(
+          `Could not configure node: ${this.name}(${this.id})`,
+          error
+        );
+      }
     }
   }
 


### PR DESCRIPTION
When replacing a node (select and node search with ctrl+F), we currently
* replace the node
* overwrite all the data of the new node with the data of the original one

This creates a problem for example when replacing an Add node with a Subtract node as the code of the Add node gets kept from the Add node. See
https://github.com/fakob/plug-and-play/assets/4619772/6af4bfbd-cb89-4c98-893b-890ff4dd9c23

In this fix I am suggesting to only overwrite position and update behaviour, but not the socket data.
https://github.com/fakob/plug-and-play/assets/4619772/d8785d93-3c81-47ac-b851-ed2abdc165e5



