### PR TITLE
Fix selection of single node overlapping after zooming or panning

### DIFF
--- a/src/classes/SelectionClass.ts
+++ b/src/classes/SelectionClass.ts
@@ -203,14 +203,14 @@ export default class PPSelection extends PIXI.Container {
   }
 
   onViewportMoved(): void {
-    this.drawRectanglesFromSelection();
+    this.drawRectanglesFromSelection(this.selectedNodes.length !== 1);
   }
 
   onPointerUpAndUpOutside(): void {
     console.log('Selection: onPointerUpAndUpOutside');
     this.stopDragAction();
     // we remove the fill of the selection on the nodes if its just one, so that sockets etc on it can be pressed
-    if (this.selectedNodes.length == 1) {
+    if (this.selectedNodes.length === 1) {
       this.drawRectanglesFromSelection(false);
     }
   }


### PR DESCRIPTION
Fixes the following issue:
When a single node is selected, the selection should be ignored and not interfere with mouse interactions.
When hovering over a socket across the selection border the selection should not interfere which works fine until you zoom/pan. Then all of a sudden the selection is actually overlaying the node and interferes with it. See video

https://github.com/fakob/plug-and-play/assets/4619772/1dd79c99-4932-4e1c-8834-897d617ed215

