### PR TITLE
Update cypress tests to use node 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ jobs:
   cypress-run:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - name: Checkout
         uses: actions/checkout@v3
       - name: install PNP


### PR DESCRIPTION
For my PR I got a cypress test error. It seems I have to run node 16.

<img width="1341" alt="Screenshot 2023-08-06 at 14 47 38" src="https://github.com/fakob/plug-and-play/assets/4619772/02f59d90-701b-4165-af25-4375ed196c8a">
