### PR TITLE
Structured node drawing into background and foreground groups

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -288,6 +288,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
       worldHeight: window.innerHeight,
       events: pixiApp.current.renderer.events,
     });
+    viewport.current.name = 'pixiViewport';
 
     globalThis.__VIEWPORT__ = viewport.current;
 
@@ -787,13 +788,13 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     async function load() {
       const remoteGraphSearchItems = remoteGraphsRef.current.map(
         (graph, index) => {
-        return {
-          id: index,
-          name: removeExtension(graph), // remove .ppgraph extension
-          label: 'remote',
-          isRemote: true,
-        } as IGraphSearch;
-        },
+          return {
+            id: index,
+            name: removeExtension(graph), // remove .ppgraph extension
+            label: 'remote',
+            isRemote: true,
+          } as IGraphSearch;
+        }
       );
       // add remote header entry
       if (remoteGraphSearchItems.length > 0) {

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -756,7 +756,7 @@ export default class PPGraph {
     this.nodes = {};
     this.nodeContainer.removeChildren();
 
-    // clearn back and foreground canvas
+    // clear back and foreground canvas
     this.backgroundCanvas.removeChildren();
     this.foregroundCanvas.removeChildren();
 
@@ -1014,7 +1014,7 @@ export default class PPGraph {
       // get links which are completely contained in selection
       node.getAllInputSockets().forEach((socket) => {
         if (socket.hasLink()) {
-          const connectedNode = socket.links[0].source.parent as PPNode;
+          const connectedNode = socket.links[0].source.getNode() as PPNode;
           nodes.includes(connectedNode)
             ? linksFullyContainedInSelection.push(socket.links[0])
             : linksPartiallyInSelection.push(socket.links[0]);

--- a/src/classes/HybridNode2.tsx
+++ b/src/classes/HybridNode2.tsx
@@ -251,11 +251,11 @@ export default abstract class HybridNode2 extends PPNode {
   }
 
   public drawBackground(): void {
-    this._BackgroundRef.beginFill(
+    this._BackgroundGraphicsRef.beginFill(
       this.getColor().hexNumber(),
       this.getOpacity(),
     );
-    this._BackgroundRef.drawRoundedRect(
+    this._BackgroundGraphicsRef.drawRoundedRect(
       NODE_MARGIN,
       0,
       this.nodeWidth,
@@ -271,7 +271,7 @@ export default abstract class HybridNode2 extends PPNode {
     } else {
       this.shadowPlane.visible = false;
     }
-    this._BackgroundRef.endFill();
+    this._BackgroundGraphicsRef.endFill();
   }
 
   onNodeRemoved = (): void => {

--- a/src/classes/LinkClass.ts
+++ b/src/classes/LinkClass.ts
@@ -29,12 +29,12 @@ export default class PPLink extends PIXI.Container {
   serialize(): SerializedLink {
     // create serialization object
     // this prevents being blocked from saving when having orphaned links
-    if (this.source.parent && this.target.parent) {
+    if (this.source.getNode() && this.target.getNode()) {
       return {
         id: this.id,
-        sourceNodeId: (this.source.parent as PPNode).id,
+        sourceNodeId: (this.source.getNode() as PPNode).id,
         sourceSocketName: this.source.name,
-        targetNodeId: (this.target.parent as PPNode).id,
+        targetNodeId: (this.target.getNode() as PPNode).id,
         targetSocketName: this.target.name,
       };
     }

--- a/src/classes/NodeClass.tsx
+++ b/src/classes/NodeClass.tsx
@@ -158,7 +158,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
 
     const inputNameText = new PIXI.Text(
       this.getNodeTextString(),
-      NODE_TEXTSTYLE
+      NODE_TEXTSTYLE,
     );
     inputNameText.x = NODE_HEADER_TEXTMARGIN_LEFT;
     inputNameText.y = NODE_PADDING_TOP + NODE_HEADER_TEXTMARGIN_TOP;
@@ -296,7 +296,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
           !(
             socketRef.name === socket.name &&
             socketRef.socketType === socket.socketType
-          )
+          ),
       );
     };
 
@@ -319,10 +319,10 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
     data?: unknown,
     visible?: boolean,
     custom?: Record<string, any>, // lets get rid of this ASAP
-    redraw = true
+    redraw = true,
   ): void {
     this.addSocket(
-      new Socket(SOCKET_TYPE.TRIGGER, name, type, data, visible, custom)
+      new Socket(SOCKET_TYPE.TRIGGER, name, type, data, visible, custom),
     );
     // redraw background due to size change
     if (redraw) {
@@ -336,10 +336,10 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
     data?: unknown,
     visible?: boolean,
     custom?: Record<string, any>, // lets get rid of this ASAP
-    redraw = true
+    redraw = true,
   ): void {
     this.addSocket(
-      new Socket(SOCKET_TYPE.IN, name, type, data, visible, custom)
+      new Socket(SOCKET_TYPE.IN, name, type, data, visible, custom),
     );
     // redraw background due to size change
     if (redraw) {
@@ -352,7 +352,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
     type: AbstractType,
     visible?: boolean,
     custom?: Record<string, any>,
-    redraw = true
+    redraw = true,
   ): void {
     this.addSocket(
       new Socket(
@@ -360,8 +360,8 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
         name,
         type,
         null, // need to get rid of this
-        visible
-      )
+        visible,
+      ),
     );
     // redraw background due to size change
     if (redraw) {
@@ -400,14 +400,15 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
     this.updateBehaviour = new UpdateBehaviourClass(
       nodeConfig.updateBehaviour.update,
       nodeConfig.updateBehaviour.interval,
-      nodeConfig.updateBehaviour.intervalFrequency
+      nodeConfig.updateBehaviour.intervalFrequency,
+      this,
     );
     if (includeSocketData) {
       try {
         const mapSocket = (item: SerializedSocket) => {
           const matchingSocket = this.getSocketByNameAndType(
             item.name,
-            item.socketType
+            item.socketType,
           );
           if (matchingSocket !== undefined) {
             matchingSocket.dataType = deSerializeType(item.dataType);
@@ -418,7 +419,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
           } else {
             // add socket if it does not exist yet
             console.info(
-              `Socket does not exist (yet) and will be created: ${this.name}(${this.id})/${item.name}`
+              `Socket does not exist (yet) and will be created: ${this.name}(${this.id})/${item.name}`,
             );
             this.addSocket(
               new Socket(
@@ -426,8 +427,8 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
                 item.name,
                 deSerializeType(item.dataType),
                 item.data,
-                item.visible
-              )
+                item.visible,
+              ),
             );
           }
         };
@@ -437,7 +438,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
       } catch (error) {
         console.error(
           `Could not configure node: ${this.name}(${this.id})`,
-          error
+          error,
         );
       }
     }
@@ -469,7 +470,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
   async executeChildren(): Promise<void> {
     this.drawComment();
     await FlowLogic.executeOptimizedChainBatch(
-      Object.values(this.getDirectDependents())
+      Object.values(this.getDirectDependents()),
     );
   }
 
@@ -503,7 +504,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
   onBeingScaled(
     width: number = this.nodeWidth,
     height: number = this.nodeHeight,
-    maintainAspectRatio = false
+    maintainAspectRatio = false,
   ): void {
     this.resizeAndDraw(width, height, maintainAspectRatio);
   }
@@ -511,7 +512,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
   resizeAndDraw(
     width: number = this.nodeWidth,
     height: number = this.nodeHeight,
-    maintainAspectRatio = false
+    maintainAspectRatio = false,
   ): void {
     // set new size
     const newNodeWidth = Math.max(width, this.getMinNodeWidth());
@@ -526,7 +527,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
         newNodeWidth,
         newNodeHeight,
         this.getMinNodeWidth(),
-        this.getMinNodeHeight()
+        this.getMinNodeHeight(),
       );
       this.nodeWidth = newRect.width;
       this.nodeHeight = newRect.height;
@@ -546,7 +547,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
 
     if (this.selected) {
       PPGraph.currentGraph.selection.drawRectanglesFromSelection(
-        PPGraph.currentGraph.selection.selectedNodes.length > 1
+        PPGraph.currentGraph.selection.selectedNodes.length > 1,
       );
     }
   }
@@ -566,7 +567,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
   getAllSockets(): Socket[] {
     return this.inputSocketArray.concat(
       this.nodeTriggerSocketArray,
-      this.outputSocketArray
+      this.outputSocketArray,
     );
   }
 
@@ -617,28 +618,28 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
   public drawErrorBoundary(): void {
     this._BackgroundGraphicsRef.beginFill(
       new TRgba(255, 0, 0).hexNumber(),
-      this.getOpacity()
+      this.getOpacity(),
     );
     this._BackgroundGraphicsRef.drawRoundedRect(
       NODE_MARGIN - 3,
       -3,
       this.nodeWidth + 6,
       this.nodeHeight + 6,
-      this.getRoundedCorners() ? NODE_CORNERRADIUS : 0
+      this.getRoundedCorners() ? NODE_CORNERRADIUS : 0,
     );
   }
 
   public drawBackground(): void {
     this._BackgroundGraphicsRef.beginFill(
       this.getColor().hexNumber(),
-      this.getOpacity()
+      this.getOpacity(),
     );
     this._BackgroundGraphicsRef.drawRoundedRect(
       NODE_MARGIN,
       0,
       this.nodeWidth,
       this.nodeHeight,
-      this.getRoundedCorners() ? NODE_CORNERRADIUS : 0
+      this.getRoundedCorners() ? NODE_CORNERRADIUS : 0,
     );
     this._BackgroundGraphicsRef.endFill();
   }
@@ -700,7 +701,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
         new TextStyle({
           fontSize: 18,
           fill: COLOR_MAIN,
-        })
+        }),
       );
       text.x = this.nodeWidth - inlet + 5; // - width;
       text.y = startY + 5 + index * (height - merging);
@@ -711,7 +712,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
         startY + index * (height - merging),
         text.width + 10,
         height,
-        NODE_CORNERRADIUS
+        NODE_CORNERRADIUS,
       );
     });
   }
@@ -743,21 +744,21 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
   public addDefaultTrigger(): void {
     this.addTrigger(
       this.constructSocketName('Trigger', this.nodeTriggerSocketArray),
-      new TriggerType()
+      new TriggerType(),
     );
   }
 
   public addDefaultInput(): void {
     this.addInput(
       this.constructSocketName('Custom Input', this.inputSocketArray),
-      new AnyType()
+      new AnyType(),
     );
   }
 
   public addDefaultOutput(): void {
     this.addOutput(
       this.constructSocketName('Custom Output', this.outputSocketArray),
-      new AnyType()
+      new AnyType(),
     );
   }
 
@@ -774,7 +775,7 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
     this._CommentRef.removeChildren();
     if (PPGraph.currentGraph._showComments) {
       let commentData = this.outputSocketArray[0]?.dataType?.getComment(
-        this.outputSocketArray[0]?.data
+        this.outputSocketArray[0]?.data,
       );
       if (commentData !== undefined && commentData.length > 10000) {
         commentData = 'Too long to display';
@@ -782,12 +783,12 @@ export default class PPNode extends PIXI.Container implements Tooltipable {
       const debugText = new PIXI.Text(
         `${this.id}
 ${Math.round(this.transform.position.x)}, ${Math.round(
-          this.transform.position.y
+          this.transform.position.y,
         )}
 ${Math.round(this._bounds.minX)}, ${Math.round(
-          this._bounds.minY
+          this._bounds.minY,
         )}, ${Math.round(this._bounds.maxX)}, ${Math.round(this._bounds.maxY)}`,
-        COMMENT_TEXTSTYLE
+        COMMENT_TEXTSTYLE,
       );
       debugText.resolution = 1;
       const nodeComment = new PIXI.Text(commentData, COMMENT_TEXTSTYLE);
@@ -931,12 +932,12 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
         if (this.successfullyExecuted) {
           activeExecution.beginFill(
             new PIXI.Color('#CCFFFF').toNumber(),
-            0.4 - i * (0.4 / iterations)
+            0.4 - i * (0.4 / iterations),
           );
         } else {
           activeExecution.beginFill(
             new TRgba(255, 0, 0).hexNumber(),
-            1.0 - i * (1.0 / iterations)
+            1.0 - i * (1.0 / iterations),
           );
         }
 
@@ -945,7 +946,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
           0,
           this.nodeWidth,
           this.nodeHeight,
-          this.getRoundedCorners() ? NODE_CORNERRADIUS : 0
+          this.getRoundedCorners() ? NODE_CORNERRADIUS : 0,
         );
         activeExecution.endFill();
         if (i == iterations) {
@@ -971,7 +972,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     } catch (error) {
       this.lastError = error;
       console.log(
-        `Node ${this.name}(${this.id}) execution error:  ${error.stack}`
+        `Node ${this.name}(${this.id}) execution error:  ${error.stack}`,
       );
       this.successfullyExecuted = false;
     }
@@ -998,7 +999,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
         type: this.type,
       },
       getCircularReplacer(),
-      2
+      2,
     );
     return (
       <>
@@ -1024,7 +1025,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     const absPos = this.getGlobalPosition();
     return new PIXI.Point(
       Math.max(0, absPos.x - TOOLTIP_WIDTH - distanceX),
-      absPos.y
+      absPos.y,
     );
   }
 
@@ -1042,7 +1043,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     this.onViewportMoveHandler = this.onViewportMove.bind(this);
     PPGraph.currentGraph.viewport.addEventListener(
       'moved',
-      (this as any).onViewportMoveHandler
+      (this as any).onViewportMoveHandler,
     );
   }
 
@@ -1073,7 +1074,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
         PPGraph.currentGraph.selection.selectNodes(
           duplicatedNodes,
           shiftKey,
-          true
+          true,
         );
       }
 
@@ -1113,7 +1114,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     // remove added listener from graph.viewport
     PPGraph.currentGraph.viewport.removeEventListener(
       'moved',
-      this.onViewportMoveHandler
+      this.onViewportMoveHandler,
     );
     this.listenId.forEach((id) => InterfaceController.removeListener(id));
 
@@ -1151,8 +1152,8 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     this.listenId.push(
       InterfaceController.addListener(
         ListenEvent.GlobalPointerUp,
-        this.onViewportPointerUpHandler
-      )
+        this.onViewportPointerUpHandler,
+      ),
     );
     // check if double clicked
     if (event.detail === 2) {
@@ -1160,8 +1161,8 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
       this.listenId.push(
         InterfaceController.addListener(
           ListenEvent.EscapeKeyUsed,
-          this.onViewportPointerUpHandler
-        )
+          this.onViewportPointerUpHandler,
+        ),
       );
       if (this.onNodeDoubleClick) {
         this.onNodeDoubleClick(event);
@@ -1177,7 +1178,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
   public hasSocketNameInDefaultIO(name: string, type: TSocketType): boolean {
     return (
       this.getAllInitialSockets().find(
-        (socket) => socket.name == name && socket.socketType == type
+        (socket) => socket.name == name && socket.socketType == type,
       ) !== undefined
     );
   }
@@ -1199,7 +1200,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(true, false, 1000);
+    return new UpdateBehaviourClass(true, false, 1000, this);
   }
 
   // override if you don't want your node to show outline for some reason

--- a/src/classes/NodeHeaderClass.ts
+++ b/src/classes/NodeHeaderClass.ts
@@ -64,7 +64,7 @@ export default class NodeHeaderClass extends PIXI.Container {
     down: boolean
   ): void {
     const altKey = event.altKey;
-    const node = this.parent as PPNode;
+    const node = this.parent?.parent as PPNode;
     const graph = PPGraph.currentGraph;
     console.log(this, node, up, down);
     graph.selection.selectNodes(
@@ -73,7 +73,7 @@ export default class NodeHeaderClass extends PIXI.Container {
   }
 
   editNodeMouseDown(): void {
-    const node = this.parent as PPNode;
+    const node = this.parent?.parent as PPNode;
     PPGraph.currentGraph.socketToInspect = null;
     const obj = {
       filter: null,

--- a/src/classes/SelectionClass.tsx
+++ b/src/classes/SelectionClass.tsx
@@ -472,7 +472,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
 
     // draw single selections
     this.selectedNodes.forEach((node) => {
-      const nodeBounds = node._BackgroundRef.getBounds();
+      const nodeBounds = node._BackgroundGraphicsRef.getBounds();
       this.singleSelectionsGraphics.drawRect(
         nodeBounds.x,
         nodeBounds.y,

--- a/src/classes/SocketClass.tsx
+++ b/src/classes/SocketClass.tsx
@@ -337,7 +337,7 @@ export default class Socket extends PIXI.Container implements Tooltipable {
   }
 
   getNode(): PPNode {
-    return this.parent as PPNode;
+    return this.parent?.parent as PPNode;
   }
 
   getGraph(): PPGraph {

--- a/src/classes/UpdateBehaviourClass.ts
+++ b/src/classes/UpdateBehaviourClass.ts
@@ -168,7 +168,7 @@ export default class UpdateBehaviourClass extends PIXI.Container {
   // METHODS
 
   getNode(): PPNode {
-    return this.parent as PPNode;
+    return this.parent?.parent as PPNode;
   }
 
   getGraph(): PPGraph {

--- a/src/classes/UpdateBehaviourClass.ts
+++ b/src/classes/UpdateBehaviourClass.ts
@@ -25,21 +25,24 @@ export default class UpdateBehaviourClass extends PIXI.Container {
   private _intervalFrequency: number;
   private _hoverNode: boolean;
   private _hover: boolean;
+  node: PPNode;
 
   constructor(
     inUpdate: boolean,
     inInterval: boolean,
-    inIntervalFrequency: number
+    inIntervalFrequency: number,
+    node: PPNode,
   ) {
     super();
 
     this._update = inUpdate;
     this._interval = inInterval;
     this._intervalFrequency = inIntervalFrequency;
+    this.node = node;
 
     const FrequencyText = new PIXI.Text(
       this._intervalFrequency.toString(),
-      UPDATEBEHAVIOURHEADER_TEXTSTYLE
+      UPDATEBEHAVIOURHEADER_TEXTSTYLE,
     );
     FrequencyText.x = 26;
     FrequencyText.y = 6;
@@ -48,22 +51,22 @@ export default class UpdateBehaviourClass extends PIXI.Container {
 
     this._frequencyRef = this.addChild(FrequencyText);
     this._frequencyRef.tint = new PIXI.Color(
-      Color(RANDOMMAINCOLOR).darken(0.7).hex()
+      Color(RANDOMMAINCOLOR).darken(0.7).hex(),
     ).toNumber();
 
     this._updateRef = this.addChild(
-      PIXI.Sprite.from(UPDATEBEHAVIOURHEADER_UPDATE)
+      PIXI.Sprite.from(UPDATEBEHAVIOURHEADER_UPDATE),
     );
     this._updateRef.tint = new PIXI.Color(
-      Color(RANDOMMAINCOLOR).darken(0.7).hex()
+      Color(RANDOMMAINCOLOR).darken(0.7).hex(),
     ).toNumber();
 
     this._noUpdateRef = this.addChild(
-      PIXI.Sprite.from(UPDATEBEHAVIOURHEADER_NOUPDATE)
+      PIXI.Sprite.from(UPDATEBEHAVIOURHEADER_NOUPDATE),
     );
     this._noUpdateRef.visible = false;
     this._noUpdateRef.tint = new PIXI.Color(
-      Color(RANDOMMAINCOLOR).darken(0.7).hex()
+      Color(RANDOMMAINCOLOR).darken(0.7).hex(),
     ).toNumber();
 
     this.addChild(this._updateRef);
@@ -78,15 +81,15 @@ export default class UpdateBehaviourClass extends PIXI.Container {
 
     this._updateRef.addEventListener(
       'pointerover',
-      this.onPointerOver.bind(this)
+      this.onPointerOver.bind(this),
     );
     this._updateRef.addEventListener(
       'pointerout',
-      this.onPointerOut.bind(this)
+      this.onPointerOut.bind(this),
     );
     this._updateRef.addEventListener(
       'pointerdown',
-      this.onPointerDown.bind(this)
+      this.onPointerDown.bind(this),
     );
 
     this._noUpdateRef.width = 24;
@@ -119,7 +122,7 @@ export default class UpdateBehaviourClass extends PIXI.Container {
   setUpdateBehaviour(
     newUpdate: boolean,
     newInterval: boolean,
-    newIntervalFrequency: number
+    newIntervalFrequency: number,
   ): void {
     this._update = newUpdate;
     this._interval = newInterval;
@@ -168,7 +171,7 @@ export default class UpdateBehaviourClass extends PIXI.Container {
   // METHODS
 
   getNode(): PPNode {
-    return this.parent?.parent as PPNode;
+    return this.node;
   }
 
   getGraph(): PPGraph {

--- a/src/components/FloatingSocketInspector.tsx
+++ b/src/components/FloatingSocketInspector.tsx
@@ -27,7 +27,7 @@ function PaperComponent(props) {
     <Draggable
       handle="#draggable-title"
       cancel={'[id=draggable-content]'}
-      key={`${props.socketinfo.parent.id}.${props.socketinfo.name}`}
+      key={`${props.socketinfo.getNode().id}.${props.socketinfo.name}`}
     >
       <Paper {...props} />
     </Draggable>
@@ -96,7 +96,7 @@ export const FloatingSocketInspector: React.FunctionComponent<MyProps> = (
               userSelect: 'none',
             }}
           >
-            {props.socketToInspect.parent?.name}
+            {props.socketToInspect.getNode()?.name}
           </Box>
           <ToggleButtonGroup
             value={newWidth}
@@ -135,7 +135,7 @@ export const FloatingSocketInspector: React.FunctionComponent<MyProps> = (
             hasLink={props.socketToInspect.hasLink()}
             data={props.socketToInspect.data}
             randomMainColor={props.randomMainColor}
-            selectedNode={props.socketToInspect.parent as PPNode}
+            selectedNode={props.socketToInspect.getNode() as PPNode}
           />
         </Box>
       </PaperComponent>

--- a/src/components/GraphOverlaySocketInspector.tsx
+++ b/src/components/GraphOverlaySocketInspector.tsx
@@ -36,7 +36,7 @@ const GraphOverlaySocketInspector: React.FunctionComponent<
 
   return (
     <Box sx={{ position: 'relative' }}>
-      {socketToInspect && socketToInspect.parent && (
+      {socketToInspect && socketToInspect.getNode() && (
         <FloatingSocketInspector
           socketInspectorPosition={socketInspectorPosition}
           socketToInspect={socketToInspect}

--- a/src/nodes/api/http.tsx
+++ b/src/nodes/api/http.tsx
@@ -50,7 +50,7 @@ export class HTTPNode extends PPNode {
   public getAdditionalDescription(): string {
     return `<p>${wrapDownloadLink(
       'https://github.com/magnificus/pnp-companion-2/releases/',
-      'Download Plug and Play Companion'
+      'Download Plug and Play Companion',
     )}</p>`;
   }
 
@@ -67,7 +67,7 @@ export class HTTPNode extends PPNode {
         SOCKET_TYPE.IN,
         urlInputName,
         new StringType(),
-        'https://jsonplaceholder.typicode.com/posts'
+        'https://jsonplaceholder.typicode.com/posts',
       ),
       new Socket(SOCKET_TYPE.IN, headersInputName, new JSONType(), {
         'Content-Type': 'application/json',
@@ -76,27 +76,27 @@ export class HTTPNode extends PPNode {
         SOCKET_TYPE.IN,
         methodName,
         new EnumType(HTTPMethodOptions),
-        HTTPMethodOptions[0].text
+        HTTPMethodOptions[0].text,
       ),
       Socket.getOptionalVisibilitySocket(
         SOCKET_TYPE.IN,
         bodyInputName,
         new JSONType(),
         {},
-        () => this.getInputData(methodName) !== 'Get'
+        () => this.getInputData(methodName) !== 'Get',
       ),
       new Socket(
         SOCKET_TYPE.IN,
         sendThroughCompanionName,
         new BooleanType(),
-        false
+        false,
       ),
       Socket.getOptionalVisibilitySocket(
         SOCKET_TYPE.IN,
         sendThroughCompanionAddress,
         new StringType(),
         companionDefaultAddress,
-        () => this.getInputData(sendThroughCompanionName)
+        () => this.getInputData(sendThroughCompanionName),
       ),
       new Socket(SOCKET_TYPE.OUT, outputContentName, new JSONType(), {}),
     ];
@@ -112,7 +112,7 @@ export class HTTPNode extends PPNode {
 
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     const usingCompanion: boolean = inputObject[sendThroughCompanionName];
     this.statuses = [];
@@ -184,12 +184,12 @@ export class ChatGPTNode extends HTTPNode {
   public getAdditionalDescription(): string {
     return `<p>${wrapDownloadLink(
       'https://github.com/magnificus/pnp-companion-2/releases/',
-      'Download Plug and Play Companion'
+      'Download Plug and Play Companion',
     )}</p>`;
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000);
+    return new UpdateBehaviourClass(false, false, 1000, this);
   }
 
   protected getDefaultIO(): Socket[] {
@@ -198,13 +198,13 @@ export class ChatGPTNode extends HTTPNode {
         SOCKET_TYPE.IN,
         urlInputName,
         new StringType(),
-        'https://api.openai.com/v1/engines/text-davinci-003/completions'
+        'https://api.openai.com/v1/engines/text-davinci-003/completions',
       ),
       new Socket(
         SOCKET_TYPE.IN,
         chatGPTPromptName,
         new StringType(),
-        'Give me a quick rundown of the battle of Hastings'
+        'Give me a quick rundown of the battle of Hastings',
       ),
       new Socket(SOCKET_TYPE.IN, chatGPTOptionsName, new JSONType(), {
         max_tokens: 100,
@@ -216,13 +216,13 @@ export class ChatGPTNode extends HTTPNode {
         SOCKET_TYPE.IN,
         chatGPTEnvironmentalVariableAuthKey,
         new StringType(),
-        'OPENAI_KEY'
+        'OPENAI_KEY',
       ),
       new Socket(
         SOCKET_TYPE.IN,
         sendThroughCompanionAddress,
         new StringType(),
-        companionDefaultAddress
+        companionDefaultAddress,
       ),
       new Socket(SOCKET_TYPE.OUT, outputContentName, new JSONType(), {}),
     ];
@@ -230,7 +230,7 @@ export class ChatGPTNode extends HTTPNode {
 
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     this.statuses = [];
     let returnResponse = {};
@@ -239,7 +239,9 @@ export class ChatGPTNode extends HTTPNode {
       statusText: 'Companion',
     });
     try {
-      const finalOptions = JSON.parse(JSON.stringify(inputObject[chatGPTOptionsName]));
+      const finalOptions = JSON.parse(
+        JSON.stringify(inputObject[chatGPTOptionsName]),
+      );
       finalOptions.prompt = inputObject[chatGPTPromptName];
       const companionSpecific = {
         finalHeaders: {

--- a/src/nodes/api/pixotopeGateway.tsx
+++ b/src/nodes/api/pixotopeGateway.tsx
@@ -40,7 +40,7 @@ export class PixotopeGatewayGet extends PPNode {
         addressName,
         new StringType(),
         gatewayAddressDefault,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.IN, targetName, new StringType(), 'Store'),
       new Socket(SOCKET_TYPE.IN, nameName, new StringType(), 'State'),
@@ -49,7 +49,7 @@ export class PixotopeGatewayGet extends PPNode {
   }
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     const target = inputObject[targetName];
     const name = inputObject[nameName];
@@ -85,7 +85,7 @@ export class PixotopeGatewaySet extends PPNode {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000);
+    return new UpdateBehaviourClass(false, false, 1000, this);
   }
 
   protected getDefaultIO(): Socket[] {
@@ -95,21 +95,21 @@ export class PixotopeGatewaySet extends PPNode {
         addressName,
         new StringType(),
         gatewayAddressDefault,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.IN, targetName, new StringType(), 'Store'),
       new Socket(
         SOCKET_TYPE.IN,
         nameName,
         new StringType(),
-        'State.ThirdParty.PlugAndPlaygroundSettable'
+        'State.ThirdParty.PlugAndPlaygroundSettable',
       ),
       new Socket(SOCKET_TYPE.IN, valueName, new AnyType(), 'TempValue'),
     ];
   }
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     const target = inputObject[targetName];
     const name = inputObject[nameName];
@@ -145,7 +145,7 @@ export class PixotopeGatewayCall extends PPNode {
         addressName,
         new StringType(),
         gatewayAddressDefault,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.IN, targetName, new StringType(), 'Store'),
       new Socket(SOCKET_TYPE.IN, methodName, new StringType(), 'VideoIO'),
@@ -158,7 +158,7 @@ export class PixotopeGatewayCall extends PPNode {
   }
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     const target = inputObject[targetName];
     const method = inputObject[methodName];
@@ -195,7 +195,7 @@ export class PixotopeGatewayCallSaveImage extends PPNode {
         addressName,
         new StringType(),
         gatewayAddressDefault,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.IN, targetName, new StringType(), 'Pipeline'),
       new Socket(SOCKET_TYPE.IN, nodeName, new StringType(), 'XXX'),
@@ -203,14 +203,14 @@ export class PixotopeGatewayCallSaveImage extends PPNode {
         SOCKET_TYPE.IN,
         scaleName,
         new NumberType(false, 0.1, 1.0, 0.01),
-        0.1
+        0.1,
       ),
       new Socket(SOCKET_TYPE.OUT, outputContentName, new ImageType(), ''),
     ];
   }
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     const address = inputObject[addressName];
     const res = await fetch(address, {
@@ -229,8 +229,7 @@ export class PixotopeGatewayCallSaveImage extends PPNode {
         },
       }),
     });
-    outputObject[outputContentName] = (
-      await res.json()
-    )[0]?.Message?.Result?.Image;
+    outputObject[outputContentName] = (await res.json())[0]?.Message?.Result
+      ?.Image;
   }
 }

--- a/src/nodes/base.ts
+++ b/src/nodes/base.ts
@@ -87,7 +87,7 @@ export class Mouse extends PPNode {
     const worldPosition = getCurrentCursorPosition();
     const screenPosition = PPGraph.currentGraph.viewport.toScreen(
       worldPosition.x,
-      worldPosition.y
+      worldPosition.y,
     );
     this.setOutputData('screen-x', Math.round(screenPosition.x));
     this.setOutputData('screen-y', Math.round(screenPosition.y));
@@ -153,7 +153,7 @@ export class Keyboard extends PPNode {
         'keep last',
         new BooleanType(),
         false,
-        false
+        false,
       ),
     ].concat(super.getDefaultIO());
   }
@@ -225,14 +225,14 @@ export class GridCoordinates extends PPNode {
         'distanceWidth',
         new NumberType(),
         110.0,
-        false
+        false,
       ),
       new PPSocket(
         SOCKET_TYPE.IN,
         'distanceHeight',
         new NumberType(),
         110.0,
-        false
+        false,
       ),
     ].concat(super.getDefaultIO());
   }
@@ -297,7 +297,7 @@ export class RangeArray extends PPNode {
       const step = input['step'] || 2;
       output['output array'] = Array.from(
         { length: (stop - start) / step + 1 },
-        (_, i) => start + i * step
+        (_, i) => start + i * step,
       );
     };
   }
@@ -346,7 +346,7 @@ export class RandomArray extends PPNode {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 10000);
+    return new UpdateBehaviourClass(false, false, 10000, this);
   }
 
   protected getDefaultIO(): PPSocket[] {
@@ -360,7 +360,7 @@ export class RandomArray extends PPNode {
 
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     const length = inputObject['length'];
     const min = inputObject['min'];
@@ -414,14 +414,14 @@ export class DateAndTime extends PPNode {
         'Date method',
         new EnumType(dateMethodsArrayOptions),
         'toUTCString',
-        false
+        false,
       ),
     ].concat(super.getDefaultIO());
   }
 
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     const dateString = inputObject['Date string'];
     const dateMethod = inputObject['Date method'];
@@ -458,9 +458,9 @@ export class If_Else extends PPNode {
 
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
-    const condition = (inputObject['Condition']);
+    const condition = inputObject['Condition'];
     if (condition) {
       outputObject['Output'] = inputObject['A'];
     } else {
@@ -499,7 +499,7 @@ export class Comparison extends PPNode {
         'Operator',
         new EnumType(COMPARISON_OPTIONS, onOptionChange),
         COMPARISON_OPTIONS[0].value,
-        false
+        false,
       ),
       new PPSocket(SOCKET_TYPE.OUT, 'Output', new BooleanType()),
     ];
@@ -507,7 +507,7 @@ export class Comparison extends PPNode {
 
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     const inputA = inputObject['A'];
     const inputB = inputObject['B'];
@@ -545,7 +545,7 @@ export class IsValid extends PPNode {
         'Condition',
         new EnumType(CONDITION_OPTIONS, onOptionChange),
         CONDITION_OPTIONS[0].text,
-        false
+        false,
       ),
       new PPSocket(SOCKET_TYPE.OUT, 'Output', new BooleanType()),
     ];
@@ -553,7 +553,7 @@ export class IsValid extends PPNode {
 
   protected async onExecute(
     inputObject: any,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     const inputA = inputObject['A'];
     const condition = inputObject['Condition'];

--- a/src/nodes/data/dataFunctions.tsx
+++ b/src/nodes/data/dataFunctions.tsx
@@ -296,7 +296,7 @@ export class CustomFunction extends PPNode {
     super(name, {
       ...customArgs,
     });
-    this.modifiedBanner = this.addChild(new PIXI.Graphics());
+    this.modifiedBanner = this._StatusesRef.addChild(new PIXI.Graphics());
     // added this to make sure all sockets are in place before anything happens (caused visual issues on load before)
     this.adaptInputs(this.getInputData(anyCodeName));
   }

--- a/src/nodes/draw/abstract.tsx
+++ b/src/nodes/draw/abstract.tsx
@@ -59,9 +59,7 @@ export abstract class DRAW_Base extends PPNode {
   }
 
   onNodeRemoved = (): void => {
-    const canvas = PPGraph.currentGraph.backgroundCanvas;
-
-    canvas.removeChild(this.deferredGraphics);
+    this._ForegroundRef.removeChild(this.deferredGraphics);
   };
 
   // you probably want to maintain this output in children
@@ -243,7 +241,7 @@ export abstract class DRAW_Base extends PPNode {
   }
 
   private handleDrawing(drawingFunction: any, absolutePosition: boolean): void {
-    this.removeChild(this.deferredGraphics);
+    this._ForegroundRef.removeChild(this.deferredGraphics);
     if (this.shouldDraw()) {
       this.deferredGraphics = new PIXI.Container();
       drawingFunction(this.deferredGraphics, {});
@@ -251,7 +249,7 @@ export abstract class DRAW_Base extends PPNode {
         this.deferredGraphics.x -= this.x;
         this.deferredGraphics.y -= this.y;
       }
-      this.addChild(this.deferredGraphics);
+      this._ForegroundRef.addChild(this.deferredGraphics);
 
       if (this.allowMovingDirectly()) {
         this.deferredGraphics.eventMode = 'dynamic';

--- a/src/nodes/image/image.ts
+++ b/src/nodes/image/image.ts
@@ -104,10 +104,10 @@ export class Image extends PPNode {
 
   public async onNodeAdded(source: TNodeSource): Promise<void> {
     this.sprite = new PIXI.Sprite();
-    this.addChild(this.sprite);
+    this._ForegroundRef.addChild(this.sprite);
 
     this.maskRef = new PIXI.Graphics();
-    this.addChild(this.maskRef);
+    this._ForegroundRef.addChild(this.maskRef);
     this.sprite.mask = this.maskRef;
 
     let texture;

--- a/src/nodes/image/shader.ts
+++ b/src/nodes/image/shader.ts
@@ -44,7 +44,6 @@ gl_FragColor = vec4(0.5,uv*vec2(sin(time),cos(time)),1.0);
 
 `;
 
-
 const vertexShaderInputName = 'Vertex';
 const fragmentShaderInputName = 'Fragment';
 const inputUniformName = 'Uniforms';
@@ -94,37 +93,42 @@ export class Shader extends DRAW_Base {
   }
   protected getDefaultIO(): Socket[] {
     return [
-      new Socket(SOCKET_TYPE.IN, inputUniformName, new JSONType(), this.getDefaultUniforms()),
+      new Socket(
+        SOCKET_TYPE.IN,
+        inputUniformName,
+        new JSONType(),
+        this.getDefaultUniforms(),
+      ),
       new Socket(
         SOCKET_TYPE.IN,
         imageInputDataName,
         new JSONType(),
-        this.getDefaultImages()
+        this.getDefaultImages(),
       ),
       new Socket(
         SOCKET_TYPE.IN,
         vertexShaderInputName,
         new CodeType(),
         this.getInitialVertex(),
-        false
+        false,
       ),
       new Socket(
         SOCKET_TYPE.IN,
         fragmentShaderInputName,
         new CodeType(),
-        this.getInitialFragment()
+        this.getInitialFragment(),
       ),
       new Socket(
         SOCKET_TYPE.IN,
         inputWidthName,
         new NumberType(false, 1, 1000),
-        200
+        200,
       ),
       new Socket(
         SOCKET_TYPE.IN,
         inputHeightName,
         new NumberType(false, 1, 1000),
-        200
+        200,
       ),
     ].concat(super.getDefaultIO());
   }
@@ -136,7 +140,7 @@ export class Shader extends DRAW_Base {
   public onNodeAdded(): void {
     super.onNodeAdded();
     this.canvas = PPGraph.currentGraph.viewport.getChildByName(
-      'backgroundCanvas'
+      'backgroundCanvas',
     ) as PIXI.Container;
 
     this.shader = PIXI.Shader.from(this.prevVertex, this.prevFragment);
@@ -151,30 +155,29 @@ export class Shader extends DRAW_Base {
     this.prevFragment = this.getInitialFragment();
   }
 
-
-
   protected drawOnContainer(
     input: any,
     container: PIXI.Container,
-    executions: { string: number }
+    executions: { string: number },
   ): void {
     input = {
       ...input,
       ...input[injectedDataName][this.getAndIncrementExecutions(executions)],
     };
 
-
-    var time = new Date().getTime() % 1000000;
+    const time = new Date().getTime() % 1000000;
 
     const uniforms = { time: time };
-    Object.keys(input[inputUniformName]).forEach(key => uniforms[key] = input[inputUniformName][key]);
+    Object.keys(input[inputUniformName]).forEach(
+      (key) => (uniforms[key] = input[inputUniformName][key]),
+    );
 
     const images: Record<string, string> = input[imageInputDataName];
 
     // got a weird crash here if i didnt check and it was invalid
-    if (typeof images == "object") {
+    if (typeof images == 'object') {
       const imageKeys = Object.keys(images);
-      imageKeys.forEach(key => {
+      imageKeys.forEach((key) => {
         uniforms[key] = PIXI.Texture.from(images[key]);
       });
     }
@@ -207,7 +210,7 @@ export class Shader extends DRAW_Base {
           0,
           0,
         ], // x, y
-        2
+        2,
       ) // the size of the attribute
 
       .addAttribute('vUV', [0, 1, 1, 1, 1, 0, 0, 0], 2)
@@ -218,7 +221,7 @@ export class Shader extends DRAW_Base {
       new PIXI.MeshMaterial(PIXI.Texture.WHITE, {
         program: this.shader.program,
         uniforms,
-      })
+      }),
     );
 
     this.positionAndScale(graphics, input);
@@ -226,7 +229,7 @@ export class Shader extends DRAW_Base {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(true, false, 16);
+    return new UpdateBehaviourClass(true, false, 16, this);
   }
 }
 
@@ -256,7 +259,6 @@ export class ImageShader extends Shader {
   }
 
   protected getDefaultImages(): Record<string, string> {
-    return { "testImage": defaultImage };
+    return { testImage: defaultImage };
   }
-
 }

--- a/src/nodes/interactivity/record.tsx
+++ b/src/nodes/interactivity/record.tsx
@@ -85,7 +85,7 @@ export class RecordLocations extends PPNode {
         }
       );
 
-      this.addChild(this.recordButton);
+      this._ForegroundRef.addChild(this.recordButton);
       this.recordButton.eventMode = 'dynamic';
     }
     this.recordButton.clear();

--- a/src/nodes/macro/macro.ts
+++ b/src/nodes/macro/macro.ts
@@ -86,19 +86,19 @@ export class Macro extends PPNode {
   }
 
   public drawBackground(): void {
-    this._BackgroundRef.beginFill(
+    this._BackgroundGraphicsRef.beginFill(
       this.getColor().hexNumber(),
       this.getOpacity()
     );
-    this._BackgroundRef.removeChild(this.textRef);
+    this._BackgroundGraphicsRef.removeChild(this.textRef);
     this.textRef = new PIXI.Text(this.getMacroText());
     this.textRef.y = -50;
     this.textRef.x = 50;
     this.textRef.style.fill = new TRgba(128, 128, 128).hexNumber();
     this.textRef.style.fontSize = 36;
-    this._BackgroundRef.addChild(this.textRef);
+    this._BackgroundGraphicsRef.addChild(this.textRef);
 
-    this._BackgroundRef.drawRoundedRect(
+    this._BackgroundGraphicsRef.drawRoundedRect(
       NODE_MARGIN,
       0,
       macroInputBlockSize,
@@ -106,7 +106,7 @@ export class Macro extends PPNode {
       this.getRoundedCorners() ? NODE_CORNERRADIUS : 0
     );
 
-    this._BackgroundRef.drawRoundedRect(
+    this._BackgroundGraphicsRef.drawRoundedRect(
       NODE_MARGIN + this.nodeWidth - macroOutputBlockSize,
       0,
       macroOutputBlockSize,
@@ -114,9 +114,12 @@ export class Macro extends PPNode {
       this.getRoundedCorners() ? NODE_CORNERRADIUS : 0
     );
 
-    this._BackgroundRef.lineStyle(3, this.getColor().multiply(0.8).hexNumber());
+    this._BackgroundGraphicsRef.lineStyle(
+      3,
+      this.getColor().multiply(0.8).hexNumber()
+    );
     drawDottedLine(
-      this._BackgroundRef,
+      this._BackgroundGraphicsRef,
       macroInputBlockSize + 5,
       5,
       this.nodeWidth - macroOutputBlockSize + 10,
@@ -124,7 +127,7 @@ export class Macro extends PPNode {
       5
     );
     drawDottedLine(
-      this._BackgroundRef,
+      this._BackgroundGraphicsRef,
       macroInputBlockSize + 5,
       this.nodeHeight,
       this.nodeWidth - macroOutputBlockSize + 10,
@@ -132,7 +135,7 @@ export class Macro extends PPNode {
       5
     );
 
-    this._BackgroundRef.endFill();
+    this._BackgroundGraphicsRef.endFill();
   }
 
   public getInputSocketXPos(): number {

--- a/src/nodes/macro/macro.ts
+++ b/src/nodes/macro/macro.ts
@@ -58,7 +58,7 @@ export class Macro extends PPNode {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000);
+    return new UpdateBehaviourClass(false, false, 1000, this);
   }
 
   onRemoved(): void {
@@ -73,12 +73,12 @@ export class Macro extends PPNode {
   private getMacroText(): string {
     let toReturn = this.nodeName + ': (';
     const linkedOutputs = this.outputSocketArray.filter((socket) =>
-      socket.hasLink()
+      socket.hasLink(),
     );
     toReturn += linkedOutputs
       .map(
         (socket) =>
-          this.getSocketDisplayName(socket) + ': ' + socket.dataType.getName()
+          this.getSocketDisplayName(socket) + ': ' + socket.dataType.getName(),
       )
       .join(',');
     toReturn += ') => ' + this.inputSocketArray[0].dataType.getName();
@@ -88,7 +88,7 @@ export class Macro extends PPNode {
   public drawBackground(): void {
     this._BackgroundGraphicsRef.beginFill(
       this.getColor().hexNumber(),
-      this.getOpacity()
+      this.getOpacity(),
     );
     this._BackgroundGraphicsRef.removeChild(this.textRef);
     this.textRef = new PIXI.Text(this.getMacroText());
@@ -103,7 +103,7 @@ export class Macro extends PPNode {
       0,
       macroInputBlockSize,
       this.nodeHeight,
-      this.getRoundedCorners() ? NODE_CORNERRADIUS : 0
+      this.getRoundedCorners() ? NODE_CORNERRADIUS : 0,
     );
 
     this._BackgroundGraphicsRef.drawRoundedRect(
@@ -111,12 +111,12 @@ export class Macro extends PPNode {
       0,
       macroOutputBlockSize,
       this.nodeHeight,
-      this.getRoundedCorners() ? NODE_CORNERRADIUS : 0
+      this.getRoundedCorners() ? NODE_CORNERRADIUS : 0,
     );
 
     this._BackgroundGraphicsRef.lineStyle(
       3,
-      this.getColor().multiply(0.8).hexNumber()
+      this.getColor().multiply(0.8).hexNumber(),
     );
     drawDottedLine(
       this._BackgroundGraphicsRef,
@@ -124,7 +124,7 @@ export class Macro extends PPNode {
       5,
       this.nodeWidth - macroOutputBlockSize + 10,
       5,
-      5
+      5,
     );
     drawDottedLine(
       this._BackgroundGraphicsRef,
@@ -132,7 +132,7 @@ export class Macro extends PPNode {
       this.nodeHeight,
       this.nodeWidth - macroOutputBlockSize + 10,
       this.nodeHeight,
-      5
+      5,
     );
 
     this._BackgroundGraphicsRef.endFill();
@@ -171,7 +171,7 @@ export class Macro extends PPNode {
   public addDefaultOutput(): void {
     this.addOutput(
       this.constructSocketName('Parameter', this.outputSocketArray),
-      new AnyType()
+      new AnyType(),
     );
   }
 
@@ -183,7 +183,7 @@ export class Macro extends PPNode {
     const allParams = ['MacroName'].concat(
       this.outputSocketArray
         .slice(0, -1)
-        .map((socket) => this.getSocketDisplayName(socket))
+        .map((socket) => this.getSocketDisplayName(socket)),
     );
     const paramLine = allParams.join(',').replaceAll(' ', '_');
     console.log('paramLine: ' + paramLine);
@@ -230,7 +230,7 @@ export class Macro extends PPNode {
     const myBounds = this.getBounds();
     const nodesInside: PPNode[] = getObjectsInsideBounds(
       Object.values(PPGraph.currentGraph.nodes),
-      myBounds
+      myBounds,
     );
     nodesInside.unshift(this);
     PPGraph.currentGraph.selection.selectNodes(nodesInside);
@@ -252,16 +252,16 @@ export class Macro extends PPNode {
 
   protected async updateAllCallers() {
     const nodesCallingMe = Object.values(PPGraph.currentGraph.nodes).filter(
-      (node) => node.isCallingMacro(this.name)
+      (node) => node.isCallingMacro(this.name),
     );
     await Promise.all(
-      nodesCallingMe.map(async (node) => await node.calledMacroUpdated())
+      nodesCallingMe.map(async (node) => await node.calledMacroUpdated()),
     );
   }
 
   protected async onExecute(
     _inputObject: any,
-    _outputObject: Record<string, unknown>
+    _outputObject: Record<string, unknown>,
   ): Promise<void> {
     // potentially demanding but important QOL, go through all nodes and see which refer to me, they need to be re-executed
     if (!this.isExecutingFromOutside) {
@@ -272,7 +272,7 @@ export class Macro extends PPNode {
 
 function buildDefaultMacroFunction(macroName: string) {
   const targetMacro = Object.values(PPGraph.currentGraph.macros).find(
-    (macro) => macro.nodeName == macroName
+    (macro) => macro.nodeName == macroName,
   );
   return targetMacro ? targetMacro.getCallMacroCode() : '';
 }
@@ -303,7 +303,7 @@ export class ExecuteMacro extends CustomFunction {
   protected getDefaultParameterTypes(): Record<string, any> {
     return {
       MacroName: new DynamicEnumType(ExecuteMacro.getOptions, () =>
-        this.generateUseNewCode()
+        this.generateUseNewCode(),
       ),
     };
   }
@@ -320,7 +320,7 @@ export class ExecuteMacro extends CustomFunction {
   public generateUseNewCode = async () => {
     this.setInputData(
       anyCodeName,
-      buildDefaultMacroFunction(this.getInputData('MacroName'))
+      buildDefaultMacroFunction(this.getInputData('MacroName')),
     );
     await this.executeOptimizedChain();
     this.resizeAndDraw(0, 0);

--- a/src/nodes/math.ts
+++ b/src/nodes/math.ts
@@ -155,12 +155,12 @@ abstract class SimpleMathOperation extends CustomFunction {
   public drawBackground(): void {
     const centerX = this.nodeWidth / 2;
     const centerY = this.nodeHeight / 2;
-    this._BackgroundRef.removeChildren();
-    this._BackgroundRef.beginFill(
+    this._BackgroundGraphicsRef.removeChildren();
+    this._BackgroundGraphicsRef.beginFill(
       this.getColor().hexNumber(),
       this.getOpacity()
     );
-    this._BackgroundRef.drawRoundedRect(
+    this._BackgroundGraphicsRef.drawRoundedRect(
       NODE_MARGIN,
       0,
       this.nodeWidth,
@@ -168,7 +168,7 @@ abstract class SimpleMathOperation extends CustomFunction {
       this.getRoundedCorners() ? NODE_CORNERRADIUS : 0
     );
 
-    //this._BackgroundRef.drawCircle(NODE_MARGIN, 0, this.nodeWidth / 2);
+    //this._BackgroundGraphicsRef.drawCircle(NODE_MARGIN, 0, this.nodeWidth / 2);
 
     const fontSize = 70;
     const text = new PIXI.Text(
@@ -182,7 +182,7 @@ abstract class SimpleMathOperation extends CustomFunction {
     );
     text.x = centerX - fontSize / 4;
     text.y = centerY - fontSize / 2;
-    this._BackgroundRef.addChild(text);
+    this._BackgroundGraphicsRef.addChild(text);
   }
 
   public socketTypeChanged(): void {

--- a/src/nodes/text.tsx
+++ b/src/nodes/text.tsx
@@ -41,7 +41,7 @@ export class Label extends PPNode {
     this.PIXITextStyle = new PIXI.TextStyle();
     this.PIXITextStyle.breakWords = true;
     const basicText = new PIXI.Text(labelDefaultText, this.PIXITextStyle);
-    this.PIXIText = this.addChild(basicText);
+    this.PIXIText = this._ForegroundRef.addChild(basicText);
     this.PIXIVisible();
   }
 

--- a/src/nodes/utility/browser.ts
+++ b/src/nodes/utility/browser.ts
@@ -32,6 +32,6 @@ export class OpenURL extends CustomFunction {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000);
+    return new UpdateBehaviourClass(false, false, 1000, this);
   }
 }

--- a/src/nodes/utility/utility.ts
+++ b/src/nodes/utility/utility.ts
@@ -76,12 +76,12 @@ export class Reroute extends PPNode {
   }
 
   public drawBackground(): void {
-    this._BackgroundRef.beginFill(
+    this._BackgroundGraphicsRef.beginFill(
       this.getColor().hexNumber(),
       this.getOpacity()
     );
-    this._BackgroundRef.drawCircle(16, 0, 14.5);
-    this._BackgroundRef.endFill();
+    this._BackgroundGraphicsRef.drawCircle(16, 0, 14.5);
+    this._BackgroundGraphicsRef.endFill();
   }
 
   protected async onExecute(

--- a/src/nodes/utility/utility.ts
+++ b/src/nodes/utility/utility.ts
@@ -78,7 +78,7 @@ export class Reroute extends PPNode {
   public drawBackground(): void {
     this._BackgroundGraphicsRef.beginFill(
       this.getColor().hexNumber(),
-      this.getOpacity()
+      this.getOpacity(),
     );
     this._BackgroundGraphicsRef.drawCircle(16, 0, 14.5);
     this._BackgroundGraphicsRef.endFill();
@@ -86,7 +86,7 @@ export class Reroute extends PPNode {
 
   protected async onExecute(
     inputObject: unknown,
-    outputObject: Record<string, unknown>
+    outputObject: Record<string, unknown>,
   ): Promise<void> {
     outputObject['Out'] = inputObject['In'];
   }
@@ -126,7 +126,7 @@ export class JumpToNode extends WidgetButton {
 
   onWidgetTrigger = () => {
     const nodeId = getNodeArrayOptions()().find(
-      (option) => option.text === this.getInputData(selectNodeName)
+      (option) => option.text === this.getInputData(selectNodeName),
     )?.value;
     const nodeToJumpTo = PPGraph.currentGraph.nodes[nodeId];
     if (nodeToJumpTo) {
@@ -145,7 +145,7 @@ export class JumpToNode extends WidgetButton {
         selectNodeName,
         new DynamicEnumType(getNodeArrayOptions),
         undefined,
-        false
+        false,
       ),
     ].concat(super.getDefaultIO());
   }
@@ -175,7 +175,7 @@ export class WriteToClipboard extends PPNode {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000);
+    return new UpdateBehaviourClass(false, false, 1000, this);
   }
 
   protected getDefaultIO(): Socket[] {
@@ -185,14 +185,14 @@ export class WriteToClipboard extends PPNode {
         'Trigger',
         new TriggerType(TRIGGER_TYPE_OPTIONS[1].text),
         undefined,
-        true
+        true,
       ),
       new Socket(
         SOCKET_TYPE.IN,
         dataToCopyName,
         new StringType(),
         undefined,
-        true
+        true,
       ),
     ].concat(super.getDefaultIO());
   }
@@ -218,7 +218,7 @@ export class WriteToClipboard extends PPNode {
           },
           function () {
             console.error('Writing to clipboard of this text failed:', input);
-          }
+          },
         );
     }
   }
@@ -251,7 +251,7 @@ export class ThrottleDebounce extends PPNode {
         'Update',
         new TriggerType(TRIGGER_TYPE_OPTIONS[0].text, 'updateDebounceFunction'),
         undefined,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.IN, 'Wait', new NumberType(), 1000, false),
       new Socket(
@@ -259,7 +259,7 @@ export class ThrottleDebounce extends PPNode {
         'Max Wait',
         new NumberType(),
         undefined,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.IN, 'Leading', new BooleanType(), false, false),
       new Socket(SOCKET_TYPE.IN, 'Trailing', new BooleanType(), true, false),
@@ -279,13 +279,13 @@ export class ThrottleDebounce extends PPNode {
         maxWait: this.getInputData('Max Wait'),
         leading: this.getInputData('Leading'),
         trailing: this.getInputData('Trailing'),
-      }
+      },
     );
   }
 
   protected async onExecute(
     inputObject: any,
-    outputObject: any
+    outputObject: any,
   ): Promise<void> {
     if (this.passThroughDebounced === undefined) {
       this.updateDebounceFunction();
@@ -330,7 +330,7 @@ export class LoadNPM extends CustomFunction {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000);
+    return new UpdateBehaviourClass(false, false, 1000, this);
   }
 
   protected getDefaultFunction(): string {

--- a/src/nodes/widgets/widgetNodes.tsx
+++ b/src/nodes/widgets/widgetNodes.tsx
@@ -111,7 +111,7 @@ export class WidgetButton extends WidgetBase {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000);
+    return new UpdateBehaviourClass(false, false, 1000, this);
   }
 
   protected getDefaultIO(): Socket[] {
@@ -123,7 +123,7 @@ export class WidgetButton extends WidgetBase {
         labelName,
         new StringType(),
         buttonDefaultName,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.OUT, outName, new AnyType()),
     ];
@@ -179,7 +179,7 @@ export class WidgetButton extends WidgetBase {
 
       this._refLabel = new PIXI.Text(
         String(this.getInputData(labelName)).toUpperCase(),
-        this.labelTextStyle
+        this.labelTextStyle,
       );
       this._refLabel.anchor.x = 0.5;
       this._refLabel.anchor.y = 0.5;
@@ -197,7 +197,7 @@ export class WidgetButton extends WidgetBase {
         0,
         this.nodeWidth - 8 * margin,
         this.nodeHeight - 8 * margin,
-        16
+        16,
       );
     this._refWidget.view.width = this.nodeWidth - 8 * margin;
     this._refWidget.view.height = this.nodeHeight - 8 * margin;
@@ -231,33 +231,33 @@ export class WidgetRadio extends WidgetBase {
         SOCKET_TYPE.IN,
         optionsName,
         new ArrayType(),
-        radioDefaultValue
+        radioDefaultValue,
       ),
       new Socket(
         SOCKET_TYPE.IN,
         selectedOptionIndex,
-        new NumberType(true, 0, 10)
+        new NumberType(true, 0, 10),
       ),
       new Socket(
         SOCKET_TYPE.IN,
         backgroundColorName,
         new ColorType(),
         new TRgba(255, 255, 255),
-        false
+        false,
       ),
       new Socket(
         SOCKET_TYPE.IN,
         foregroundColorName,
         new ColorType(),
         new TRgba(0, 0, 0),
-        false
+        false,
       ),
       new Socket(
         SOCKET_TYPE.IN,
         textColorName,
         new ColorType(),
         new TRgba(255, 255, 255),
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.OUT, selectedOptionName, new StringType()),
     ];
@@ -305,7 +305,7 @@ export class WidgetRadio extends WidgetBase {
               fill: textColor,
             },
           },
-        })
+        }),
       );
     }
 
@@ -313,7 +313,7 @@ export class WidgetRadio extends WidgetBase {
     const radioGroup = new RadioGroup({
       selectedItem: Math.min(
         inputs.length - 1,
-        Math.max(this.getInputData(selectedOptionIndex), 0)
+        Math.max(this.getInputData(selectedOptionIndex), 0),
       ),
       items,
       type: 'vertical',
@@ -334,7 +334,7 @@ export class WidgetRadio extends WidgetBase {
         this.id,
         this.getInputData(selectedOptionIndex),
         selectedItemID,
-        applyFunction
+        applyFunction,
       );
     });
 
@@ -345,7 +345,7 @@ export class WidgetRadio extends WidgetBase {
 
   drawRadio(checked, width, padding) {
     const graphics = new PIXI.Graphics().beginFill(
-      this.getInputData(backgroundColorName)
+      this.getInputData(backgroundColorName),
     );
 
     graphics.drawCircle(width / 2, width / 2, width / 2);
@@ -364,9 +364,9 @@ export class WidgetRadio extends WidgetBase {
         0,
         Math.min(
           input[optionsName].length - 1,
-          this.getInputData(selectedOptionIndex)
-        )
-      )
+          this.getInputData(selectedOptionIndex),
+        ),
+      ),
     );
     this.drawNodeShape();
     const preferredHeight = this.radio.height + this.radio.y * 2;
@@ -421,14 +421,14 @@ export class WidgetColorPicker extends WidgetHybridBase {
         initialValueName,
         new ColorType(),
         RANDOMMAINCOLOR,
-        false
+        false,
       ),
       new Socket(
         SOCKET_TYPE.IN,
         labelName,
         new StringType(),
         pickerDefaultName,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.OUT, outName, new ColorType()),
     ];
@@ -463,7 +463,7 @@ export class WidgetColorPicker extends WidgetHybridBase {
     const node = props.node;
     const ref = useRef<HTMLDivElement | null>(null);
     const [finalColor, setFinalColor] = useState(
-      props[initialValueName] || TRgba.white()
+      props[initialValueName] || TRgba.white(),
     );
     const [colorPicker, showColorPicker] = useState(false);
 
@@ -481,7 +481,7 @@ export class WidgetColorPicker extends WidgetHybridBase {
         pickedrgb.r,
         pickedrgb.g,
         pickedrgb.b,
-        pickedrgb.a
+        pickedrgb.a,
       );
       const applyFunction = (value) => {
         const safeNode = ActionHandler.getSafeNode(id) as WidgetColorPicker;
@@ -602,7 +602,7 @@ export class WidgetSwitch extends WidgetHybridBase {
         selectedName,
         new BooleanType(),
         switchDefaultData,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.IN, offValueName, new AnyType(), 0, false),
       new Socket(SOCKET_TYPE.IN, onValueName, new AnyType(), 1, false),
@@ -611,7 +611,7 @@ export class WidgetSwitch extends WidgetHybridBase {
         labelName,
         new StringType(),
         switchDefaultName,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.OUT, outName, new AnyType()),
     ];
@@ -673,7 +673,7 @@ export class WidgetSwitch extends WidgetHybridBase {
         node.id,
         selected,
         !selected,
-        applyAction
+        applyAction,
       );
     };
 
@@ -766,7 +766,7 @@ export class WidgetSlider extends WidgetBase {
         initialValueName,
         new NumberType(),
         sliderDefaultValue,
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.IN, minValueName, new NumberType(), 0, false),
       new Socket(SOCKET_TYPE.IN, maxValueName, new NumberType(), 100, false),
@@ -809,7 +809,7 @@ export class WidgetSlider extends WidgetBase {
       // Label
       this._refLabel = new PIXI.Text(
         String(this.getInputData(labelName)),
-        this.labelTextStyle
+        this.labelTextStyle,
       );
       this._refLabel.anchor.x = 0.5;
       this._refLabel.anchor.y = 1;
@@ -819,7 +819,7 @@ export class WidgetSlider extends WidgetBase {
       // Value
       this._refValue = new PIXI.Text(
         String(this.getInputData(initialValueName)),
-        this.valueTextStyle
+        this.valueTextStyle,
       );
       this._refValue.anchor.x = 0.5;
       this._refValue.anchor.y = 0;
@@ -838,7 +838,7 @@ export class WidgetSlider extends WidgetBase {
         0,
         this.nodeWidth - 8 * margin,
         this.nodeHeight - 2 * fontSize - 8 * margin,
-        16
+        16,
       );
 
     this._refFill.clear();
@@ -849,7 +849,7 @@ export class WidgetSlider extends WidgetBase {
         0,
         this.nodeWidth - 8 * margin,
         this.nodeHeight - 2 * fontSize - 8 * margin,
-        16
+        16,
       );
     this._refWidget.y =
       (this.nodeHeight - (this.nodeHeight - 2 * fontSize - 8 * margin)) / 2;
@@ -858,7 +858,7 @@ export class WidgetSlider extends WidgetBase {
     this._refValue.style.fontSize = fontSize;
 
     this._refWidget.progress = this.valueToPercent(
-      this.getInputData(initialValueName)
+      this.getInputData(initialValueName),
     );
 
     this._refLabel.x = NODE_MARGIN + this.nodeWidth / 2;
@@ -884,7 +884,7 @@ export class WidgetSlider extends WidgetBase {
     const id = this.id;
     const applyFunction = (newValue) => {
       const safeNode: WidgetSlider = ActionHandler.getSafeNode(
-        id
+        id,
       ) as WidgetSlider;
       safeNode.setInputData(initialValueName, newValue);
 
@@ -897,7 +897,7 @@ export class WidgetSlider extends WidgetBase {
       this.id,
       this.getInputData(initialValueName),
       value,
-      applyFunction
+      applyFunction,
     );
   };
 
@@ -949,28 +949,28 @@ export class WidgetDropdown extends WidgetHybridBase {
         optionsName,
         new ArrayType(),
         defaultOptions,
-        false
+        false,
       ),
       new Socket(
         SOCKET_TYPE.IN,
         selectedOptionName,
         new ArrayType(),
         undefined,
-        false
+        false,
       ),
       new Socket(
         SOCKET_TYPE.IN,
         multiSelectName,
         new BooleanType(),
         false,
-        false
+        false,
       ),
       new Socket(
         SOCKET_TYPE.IN,
         labelName,
         new StringType(),
         'Dropdown',
-        false
+        false,
       ),
       new Socket(SOCKET_TYPE.OUT, outName, new AnyType()),
     ];
@@ -1005,7 +1005,7 @@ export class WidgetDropdown extends WidgetHybridBase {
     const node = props.node;
     const [options, setOptions] = useState<any[]>(props[optionsName]);
     const [selectedOption, setSelectedOption] = useState<string | string[]>(
-      formatSelected(props[selectedOptionName], props[multiSelectName])
+      formatSelected(props[selectedOptionName], props[multiSelectName]),
     );
     node.setSelectedOption = setSelectedOption;
 
@@ -1038,7 +1038,7 @@ export class WidgetDropdown extends WidgetHybridBase {
         node.id,
         selectedOption,
         formattedValue,
-        applyFunction
+        applyFunction,
       );
     };
 
@@ -1054,7 +1054,7 @@ export class WidgetDropdown extends WidgetHybridBase {
     useEffect(() => {
       const formattedValue = formatSelected(
         props[selectedOptionName],
-        props[multiSelectName]
+        props[multiSelectName],
       );
       setOptions(props[optionsName]);
       setSelectedOption(formattedValue);
@@ -1116,7 +1116,7 @@ export class WidgetDropdown extends WidgetHybridBase {
 
 const formatSelected = (
   selected: unknown,
-  multiSelect: boolean
+  multiSelect: boolean,
 ): string | string[] => {
   if (multiSelect && !Array.isArray(selected)) {
     return String(selected).split(',');

--- a/src/nodes/widgets/widgetNodes.tsx
+++ b/src/nodes/widgets/widgetNodes.tsx
@@ -175,7 +175,7 @@ export class WidgetButton extends WidgetBase {
       this._refWidget.view.y = 4 * margin;
       this._refWidget.onDown.connect(this.handleOnPointerDown);
       this._refWidget.onUp.connect(this.handleOnPointerUp);
-      this.addChild(this._refWidget.view);
+      this._ForegroundRef.addChild(this._refWidget.view);
 
       this._refLabel = new PIXI.Text(
         String(this.getInputData(labelName)).toUpperCase(),
@@ -184,7 +184,7 @@ export class WidgetButton extends WidgetBase {
       this._refLabel.anchor.x = 0.5;
       this._refLabel.anchor.y = 0.5;
       this._refLabel.eventMode = 'none';
-      this.addChild(this._refLabel);
+      this._ForegroundRef.addChild(this._refLabel);
     }
 
     const fontSize = this.nodeHeight / 6;
@@ -281,7 +281,7 @@ export class WidgetRadio extends WidgetBase {
 
   public drawNodeShape(): void {
     super.drawNodeShape();
-    this.removeChild(this.radio);
+    this._ForegroundRef.removeChild(this.radio);
 
     const inputs: [] = this.getInputData(optionsName);
     if (!Array.isArray(inputs)) {
@@ -340,7 +340,7 @@ export class WidgetRadio extends WidgetBase {
 
     this.radio = radioGroup;
 
-    this.addChild(this.radio);
+    this._ForegroundRef.addChild(this.radio);
   }
 
   drawRadio(checked, width, padding) {
@@ -804,7 +804,7 @@ export class WidgetSlider extends WidgetBase {
       });
       this._refWidget.x = NODE_MARGIN + 4 * margin;
       this._refWidget.onUpdate.connect(this.handleOnChange);
-      this.addChild(this._refWidget);
+      this._ForegroundRef.addChild(this._refWidget);
 
       // Label
       this._refLabel = new PIXI.Text(
@@ -814,7 +814,7 @@ export class WidgetSlider extends WidgetBase {
       this._refLabel.anchor.x = 0.5;
       this._refLabel.anchor.y = 1;
       this._refLabel.eventMode = 'none';
-      this.addChild(this._refLabel);
+      this._ForegroundRef.addChild(this._refLabel);
 
       // Value
       this._refValue = new PIXI.Text(
@@ -825,7 +825,7 @@ export class WidgetSlider extends WidgetBase {
       this._refValue.anchor.y = 0;
       this._refValue.y = margin;
       this._refValue.eventMode = 'none';
-      this.addChild(this._refValue);
+      this._ForegroundRef.addChild(this._refValue);
     }
 
     const fontSize = this.nodeHeight / 6;

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -552,7 +552,7 @@ export const TriggerWidget: React.FunctionComponent<TriggerWidgetProps> = (
             startIcon={<PlayArrowIcon />}
             onClick={() => {
               // nodes with trigger input need a trigger function
-              (props.property.parent as any)[
+              (props.property.getNode() as any)[
                 customFunctionString === ''
                   ? 'executeOptimizedChain'
                   : customFunctionString


### PR DESCRIPTION
I have structured the internals of the node layers a bit and separated them into
* background
  * pretty much the whole node including background, header, sockets
* foreground
  * what ever is rendered, either on top of it (in case of widgets), or outside of it (in case of render nodes)


<img width="1214" alt="Screenshot 2023-09-18 at 19 26 49" src="https://github.com/fakob/plug-and-play/assets/4619772/dbd7935e-fc37-4746-b3d3-b38804954c07">
<img width="1214" alt="Screenshot 2023-09-18 at 19 27 05" src="https://github.com/fakob/plug-and-play/assets/4619772/548d1484-5a74-4391-b456-993819478811">
