### PR TITLE
Update graph search header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1005,7 +1005,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
               setIsGraphContextMenuOpen((isOpen) => !isOpen);
             }}
           />
-          <Box className={styles.userMenu}>
+          {/* <Box className={styles.userMenu}>
             <Button
               onClick={() => {
                 setShowSharePlayground(true);
@@ -1023,7 +1023,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
                 Logout
               </Button>
             )}
-          </Box>
+          </Box> */}
           {PPGraph.currentGraph && (
             <>
               <Autocomplete
@@ -1065,6 +1065,9 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
                     randommaincolor={RANDOMMAINCOLOR}
                   />
                 )}
+                componentsProps={{
+                  popper: { style: { width: 'fit-content' } },
+                }}
               />
               <div
                 style={{

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -966,6 +966,8 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
               showComments={showComments}
               setShowComments={setShowComments}
               zoomToFitNodes={zoomToFitNodes}
+              setShowSharePlayground={setShowSharePlayground}
+              isLoggedIn={isLoggedIn}
             />
           )}
           {isNodeContextMenuOpen && (
@@ -1005,25 +1007,6 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
               setIsGraphContextMenuOpen((isOpen) => !isOpen);
             }}
           />
-          {/* <Box className={styles.userMenu}>
-            <Button
-              onClick={() => {
-                setShowSharePlayground(true);
-              }}
-            >
-              Share
-            </Button>
-            {isLoggedIn && (
-              <Button
-                onClick={() => {
-                  const currentUrl = window.location.href;
-                  window.location.href = `/logout?redirectUrl=${currentUrl}`;
-                }}
-              >
-                Logout
-              </Button>
-            )}
-          </Box> */}
           {PPGraph.currentGraph && (
             <>
               <Autocomplete
@@ -1063,6 +1046,8 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
                     {...props}
                     inputRef={graphSearchInput}
                     randommaincolor={RANDOMMAINCOLOR}
+                    setShowSharePlayground={setShowSharePlayground}
+                    isLoggedIn={isLoggedIn}
                   />
                 )}
                 componentsProps={{

--- a/src/PPStorage.tsx
+++ b/src/PPStorage.tsx
@@ -268,6 +268,17 @@ export default class PPStorage {
     }
   }
 
+  async getGraphNameFromDB(graphId = undefined): Promise<undefined | string> {
+    try {
+      const loadedGraphId = PPGraph.currentGraph.id;
+      const graph = await this.db.graphs.get(graphId || loadedGraphId);
+      return graph.name;
+    } catch (e) {
+      console.log(e.stack || e);
+      return undefined;
+    }
+  }
+
   async getGraphFromDB(id: string): Promise<undefined | Graph> {
     try {
       const loadedGraph = await this.db.graphs.get(id);

--- a/src/PPStorage.tsx
+++ b/src/PPStorage.tsx
@@ -268,14 +268,13 @@ export default class PPStorage {
     }
   }
 
-  async getGraphNameFromDB(graphId = undefined): Promise<undefined | string> {
+  async getGraphNameFromDB(graphId: string): Promise<undefined | string> {
     try {
-      const loadedGraphId = PPGraph.currentGraph.id;
-      const graph = await this.db.graphs.get(graphId || loadedGraphId);
+      const graph = await this.db.graphs.get(graphId);
       return graph.name;
     } catch (e) {
       console.log(e.stack || e);
-      return undefined;
+      return '';
     }
   }
 

--- a/src/components/ContextMenus.tsx
+++ b/src/components/ContextMenus.tsx
@@ -31,6 +31,8 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import SensorsIcon from '@mui/icons-material/Sensors';
 import MouseIcon from '@mui/icons-material/Mouse';
 import SwipeIcon from '@mui/icons-material/Swipe';
+import ShareIcon from '@mui/icons-material/Share';
+import LogoutIcon from '@mui/icons-material/Logout';
 import PPSocket from './../classes/SocketClass';
 import InterfaceController, { ListenEvent } from '../InterfaceController';
 import {
@@ -57,7 +59,7 @@ const useStyles = makeStyles((theme) =>
     active: {
       backgroundColor: 'rgba(255, 255, 255, 0.04)',
     },
-  })
+  }),
 );
 
 type SubMenuItemProps = MenuItemProps & {
@@ -124,7 +126,7 @@ const GestureModeMenuItem = (props) => {
       onClick={() => {
         PPStorage.getInstance().applyGestureMode(
           PPGraph.currentGraph.viewport,
-          props.gestureMode
+          props.gestureMode,
         );
       }}
     >
@@ -232,6 +234,25 @@ export const GraphContextMenu = (props) => {
           </ListItemIcon>
           <ListItemText>Download</ListItemText>
         </MenuItem>
+        <MenuItem onClick={() => props.setShowSharePlayground(true)}>
+          <ListItemIcon>
+            <ShareIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Share</ListItemText>
+        </MenuItem>
+        {props.isLoggedIn && (
+          <MenuItem
+            onClick={() => {
+              const currentUrl = window.location.href;
+              window.location.href = `/logout?redirectUrl=${currentUrl}`;
+            }}
+          >
+            <ListItemIcon>
+              <LogoutIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>Logout</ListItemText>
+          </MenuItem>
+        )}
         <MenuItem
           sx={{ mt: 1 }}
           onClick={() => {
@@ -450,7 +471,7 @@ const AlignOptionMenuItem = (props) => {
 
 export const NodeContextMenu = (props) => {
   const [selectionCount, setSelectionCount] = useState(
-    PPGraph.currentGraph.selection.selectedNodes.length
+    PPGraph.currentGraph.selection.selectedNodes.length,
   );
   useEffect(() => {
     window.addEventListener('contextmenu', handleContextMenu);
@@ -607,7 +628,7 @@ export const NodeContextMenu = (props) => {
         )}
         {PPGraph.currentGraph && selectionCount > 0
           ? constructListOptions(
-              PPGraph.currentGraph.selection.selectedNodes[0].getAdditionalRightClickOptions()
+              PPGraph.currentGraph.selection.selectedNodes[0].getAdditionalRightClickOptions(),
             )
           : ''}
       </MenuList>
@@ -624,7 +645,7 @@ function constructRecommendedNodeOptions(selectedSocket: PPSocket): any {
         onClick={() => {
           PPGraph.currentGraph.action_addWidgetNode(
             selectedSocket,
-            preferredNodesType
+            preferredNodesType,
           );
         }}
       >
@@ -668,7 +689,7 @@ export const SocketContextMenu = (props) => {
   const node: PPNode = selectedSocket.getNode();
   const isDeletable = !node.hasSocketNameInDefaultIO(
     selectedSocket.name,
-    selectedSocket.socketType
+    selectedSocket.socketType,
   );
 
   return (
@@ -689,7 +710,7 @@ export const SocketContextMenu = (props) => {
             PPGraph.currentGraph.selection.selectNodes(
               [selectedSocket.getNode()],
               false,
-              true
+              true,
             );
             PPGraph.currentGraph.socketToInspect = selectedSocket;
             InterfaceController.notifyListeners(
@@ -697,7 +718,7 @@ export const SocketContextMenu = (props) => {
               {
                 socket: PPGraph.currentGraph.socketToInspect,
                 open: true,
-              }
+              },
             );
           }}
         >
@@ -712,7 +733,7 @@ export const SocketContextMenu = (props) => {
             <MenuItem
               onClick={() => {
                 selectedSocket.links.forEach((link) =>
-                  PPGraph.currentGraph.action_Disconnect(link)
+                  PPGraph.currentGraph.action_Disconnect(link),
                 );
               }}
             >

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -14,6 +14,7 @@ import {
   createFilterOptions,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
 import DownloadIcon from '@mui/icons-material/Download';
 import DeleteIcon from '@mui/icons-material/Delete';
 import LinkIcon from '@mui/icons-material/Link';
@@ -21,7 +22,6 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { matchSorter } from 'match-sorter';
 import parse from 'autosuggest-highlight/parse';
 import match from 'autosuggest-highlight/match';
-import styles from '../utils/style.module.css';
 import PPGraph from '../classes/GraphClass';
 import PPStorage from '../PPStorage';
 import { getAllNodeTypes } from '../nodes/allNodes';
@@ -30,11 +30,13 @@ import { COLOR_DARK, COLOR_WHITE_TEXT } from '../utils/constants';
 import {
   getLoadGraphExampleURL,
   getLoadNodeExampleURL,
+  useIsSmallScreen,
   writeTextToClipboard,
 } from '../utils/utils';
 import InterfaceController from '../InterfaceController';
 
 export const GraphSearchInput = (props) => {
+  const smallScreen = useIsSmallScreen();
   const [currentGraphName, setCurrentGraphName] = useState('');
   const backgroundColor = Color(props.randommaincolor).alpha(0.8);
 
@@ -60,46 +62,63 @@ export const GraphSearchInput = (props) => {
         backgroundColor: `${backgroundColor}`,
       }}
     >
-      <Box
-      // className={styles.userMenu}
-      >
-        <Button
-          sx={{
-            px: 1,
-            borderRadius: '14px 2px 2px 14px',
-            color: TRgba.fromString(props.randommaincolor)
-              .getContrastTextColor()
-              .hex(),
-            '&:hover': {
-              backgroundColor: TRgba.fromString(props.randommaincolor)
-                .darken(0.05)
-                .hex(),
-            },
-          }}
-          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-            event.stopPropagation();
-            // InterfaceController.setIsGraphSearchOpen(false);
-          }}
-        >
-          Share
-        </Button>
-        {/* {isLoggedIn && (
+      {!smallScreen && (
+        <ButtonGroup>
           <Button
-            onClick={() => {
-              const currentUrl = window.location.href;
-              window.location.href = `/logout?redirectUrl=${currentUrl}`;
+            variant="text"
+            title="Share this playground"
+            sx={{
+              px: 1,
+              borderRadius: '14px 2px 2px 14px',
+              color: TRgba.fromString(props.randommaincolor)
+                .getContrastTextColor()
+                .hex(),
+              '&:hover': {
+                backgroundColor: TRgba.fromString(props.randommaincolor)
+                  .darken(0.05)
+                  .hex(),
+              },
+            }}
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+              event.stopPropagation();
+              props.setShowSharePlayground(true);
             }}
           >
-            Logout
+            Share
           </Button>
-        )} */}
-      </Box>
+          {props.isLoggedIn && (
+            <Button
+              variant="text"
+              title="Logour from Github"
+              onClick={() => {
+                const currentUrl = window.location.href;
+                window.location.href = `/logout?redirectUrl=${currentUrl}`;
+              }}
+              sx={{
+                px: 1,
+                borderRadius: '2px',
+                color: TRgba.fromString(props.randommaincolor)
+                  .getContrastTextColor()
+                  .hex(),
+                '&:hover': {
+                  backgroundColor: TRgba.fromString(props.randommaincolor)
+                    .darken(0.05)
+                    .hex(),
+                },
+              }}
+            >
+              Logout
+            </Button>
+          )}
+        </ButtonGroup>
+      )}
       <Typography
         title={`${currentGraphName} (${PPGraph?.currentGraph?.id})`}
         sx={{
           pl: 1,
           fontSize: '16px',
-          width: '100%',
+          width: '80%',
+          maxWidth: '240px',
           color: TRgba.fromString(props.randommaincolor)
             .getContrastTextColor()
             .hex(),
@@ -111,31 +130,36 @@ export const GraphSearchInput = (props) => {
       >
         {currentGraphName}
       </Typography>
-      <IconButton
-        sx={{ mr: 1 }}
-        size="small"
-        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-          event.stopPropagation();
-          // InterfaceController.setIsGraphSearchOpen(false);
-        }}
-        title="Create new playground"
-        className="menuItemButton"
-      >
-        <EditIcon
+      {!smallScreen && (
+        <IconButton
           sx={{
-            fontSize: '20px',
-            // borderRadius: '2px 14px 14px 2px',
-            color: TRgba.fromString(props.randommaincolor)
-              .getContrastTextColor()
-              .hex(),
+            p: '9px',
+            mr: '2px',
+            borderRadius: '2px',
             '&:hover': {
               backgroundColor: TRgba.fromString(props.randommaincolor)
                 .darken(0.05)
                 .hex(),
             },
           }}
-        />
-      </IconButton>
+          size="small"
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            event.stopPropagation();
+            PPStorage.getInstance().saveGraphAction();
+          }}
+          title="Save this playground"
+          className="menuItemButton"
+        >
+          <SaveIcon
+            sx={{
+              fontSize: '18px',
+              color: TRgba.fromString(props.randommaincolor)
+                .getContrastTextColor()
+                .hex(),
+            }}
+          />
+        </IconButton>
+      )}
       <TextField
         {...props}
         hiddenLabel
@@ -149,7 +173,7 @@ export const GraphSearchInput = (props) => {
         }}
         sx={{
           margin: 0,
-          borderRadius: '2px',
+          borderRadius: smallScreen ? '2px 14px 14px 2px' : '2px',
           fontSize: '16px',
           backgroundColor: `${backgroundColor}`,
           '&&& .MuiInputBase-root': {
@@ -164,27 +188,31 @@ export const GraphSearchInput = (props) => {
           },
         }}
       />
-      <Button
-        // color="secondary"
-        sx={{
-          px: 1,
-          borderRadius: '2px 14px 14px 2px',
-          color: TRgba.fromString(props.randommaincolor)
-            .getContrastTextColor()
-            .hex(),
-          '&:hover': {
-            backgroundColor: TRgba.fromString(props.randommaincolor)
-              .darken(0.05)
+      {!smallScreen && (
+        <Button
+          variant="text"
+          title="Create empty playground"
+          sx={{
+            px: 1,
+            borderRadius: '2px 14px 14px 2px',
+            color: TRgba.fromString(props.randommaincolor)
+              .getContrastTextColor()
               .hex(),
-          },
-        }}
-        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-          event.stopPropagation();
-          // InterfaceController.setIsGraphSearchOpen(false);
-        }}
-      >
-        New
-      </Button>
+            '&:hover': {
+              backgroundColor: TRgba.fromString(props.randommaincolor)
+                .darken(0.05)
+                .hex(),
+            },
+          }}
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            event.stopPropagation();
+            PPGraph.currentGraph.clear();
+            PPStorage.getInstance().saveNewGraph();
+          }}
+        >
+          New
+        </Button>
+      )}
     </Paper>
   );
 };

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -14,7 +14,6 @@ import {
   createFilterOptions,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
-import SaveIcon from '@mui/icons-material/Save';
 import DownloadIcon from '@mui/icons-material/Download';
 import DeleteIcon from '@mui/icons-material/Delete';
 import LinkIcon from '@mui/icons-material/Link';

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -66,9 +66,11 @@ export const GraphSearchInput = (props) => {
         <ButtonGroup>
           <Button
             variant="text"
+            size="small"
             title="Share this playground"
             sx={{
               px: 1,
+              py: '6px',
               borderRadius: '14px 2px 2px 14px',
               color: TRgba.fromString(props.randommaincolor)
                 .getContrastTextColor()
@@ -89,6 +91,7 @@ export const GraphSearchInput = (props) => {
           {props.isLoggedIn && (
             <Button
               variant="text"
+              size="small"
               title="Logour from Github"
               onClick={() => {
                 const currentUrl = window.location.href;
@@ -96,6 +99,7 @@ export const GraphSearchInput = (props) => {
               }}
               sx={{
                 px: 1,
+                py: '6px',
                 borderRadius: '2px',
                 color: TRgba.fromString(props.randommaincolor)
                   .getContrastTextColor()
@@ -131,34 +135,30 @@ export const GraphSearchInput = (props) => {
         {currentGraphName}
       </Typography>
       {!smallScreen && (
-        <IconButton
+        <Button
+          variant="text"
+          size="small"
+          title="Save this playground"
           sx={{
-            p: '9px',
-            mr: '2px',
+            px: 1,
+            py: '6px',
             borderRadius: '2px',
+            color: TRgba.fromString(props.randommaincolor)
+              .getContrastTextColor()
+              .hex(),
             '&:hover': {
               backgroundColor: TRgba.fromString(props.randommaincolor)
                 .darken(0.05)
                 .hex(),
             },
           }}
-          size="small"
           onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
             event.stopPropagation();
             PPStorage.getInstance().saveGraphAction();
           }}
-          title="Save this playground"
-          className="menuItemButton"
         >
-          <SaveIcon
-            sx={{
-              fontSize: '18px',
-              color: TRgba.fromString(props.randommaincolor)
-                .getContrastTextColor()
-                .hex(),
-            }}
-          />
-        </IconButton>
+          Save
+        </Button>
       )}
       <TextField
         {...props}
@@ -191,9 +191,11 @@ export const GraphSearchInput = (props) => {
       {!smallScreen && (
         <Button
           variant="text"
+          size="small"
           title="Create empty playground"
           sx={{
             px: 1,
+            py: '6px',
             borderRadius: '2px 14px 14px 2px',
             color: TRgba.fromString(props.randommaincolor)
               .getContrastTextColor()

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,13 +1,16 @@
-import * as React from 'react';
+import React, { useEffect, useState } from 'react';
 import Color from 'color';
 import { hri } from 'human-readable-ids';
 import { v4 as uuid } from 'uuid';
 import {
   Box,
+  Button,
   ButtonGroup,
   IconButton,
+  Paper,
   Stack,
   TextField,
+  Typography,
   createFilterOptions,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
@@ -18,10 +21,11 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { matchSorter } from 'match-sorter';
 import parse from 'autosuggest-highlight/parse';
 import match from 'autosuggest-highlight/match';
+import styles from '../utils/style.module.css';
 import PPGraph from '../classes/GraphClass';
 import PPStorage from '../PPStorage';
 import { getAllNodeTypes } from '../nodes/allNodes';
-import { IGraphSearch, INodeSearch } from '../utils/interfaces';
+import { IGraphSearch, INodeSearch, TRgba } from '../utils/interfaces';
 import { COLOR_DARK, COLOR_WHITE_TEXT } from '../utils/constants';
 import {
   getLoadGraphExampleURL,
@@ -31,38 +35,157 @@ import {
 import InterfaceController from '../InterfaceController';
 
 export const GraphSearchInput = (props) => {
+  const [currentGraphName, setCurrentGraphName] = useState('');
   const backgroundColor = Color(props.randommaincolor).alpha(0.8);
+
+  useEffect(() => {
+    PPStorage.getInstance()
+      .getGraphNameFromDB()
+      .then((name) => {
+        setCurrentGraphName(name);
+      });
+  }, [PPGraph.currentGraph?.id]);
+
   return (
-    <TextField
-      {...props}
-      hiddenLabel
-      inputRef={props.inputRef}
-      variant="filled"
-      placeholder="Search playgrounds"
-      InputProps={{
-        ...props.InputProps,
-        disableUnderline: true,
-        endAdornment: null,
-      }}
+    <Paper
+      component="form"
+      elevation={0}
       sx={{
-        margin: 0,
-        borderRadius: '16px',
-        fontSize: '16px',
+        p: '0px 2px  0px 2px',
+        display: 'flex',
+        alignItems: 'center',
+        width: '100%',
         height: '40px',
-        lineHeight: '40px',
+        borderRadius: '16px',
         backgroundColor: `${backgroundColor}`,
-        '&&& .MuiInputBase-root': {
-          backgroundColor: 'transparent',
-        },
-        '&&&& input': {
-          paddingBottom: '8px',
-          paddingTop: '8px',
-          color: Color(props.randommaincolor).isDark()
-            ? COLOR_WHITE_TEXT
-            : COLOR_DARK,
-        },
       }}
-    />
+    >
+      <Box
+      // className={styles.userMenu}
+      >
+        <Button
+          sx={{
+            px: 1,
+            borderRadius: '14px 2px 2px 14px',
+            color: TRgba.fromString(props.randommaincolor)
+              .getContrastTextColor()
+              .hex(),
+            '&:hover': {
+              backgroundColor: TRgba.fromString(props.randommaincolor)
+                .darken(0.05)
+                .hex(),
+            },
+          }}
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            event.stopPropagation();
+            // InterfaceController.setIsGraphSearchOpen(false);
+          }}
+        >
+          Share
+        </Button>
+        {/* {isLoggedIn && (
+          <Button
+            onClick={() => {
+              const currentUrl = window.location.href;
+              window.location.href = `/logout?redirectUrl=${currentUrl}`;
+            }}
+          >
+            Logout
+          </Button>
+        )} */}
+      </Box>
+      <Typography
+        title={`${currentGraphName} (${PPGraph?.currentGraph?.id})`}
+        sx={{
+          pl: 1,
+          fontSize: '16px',
+          width: '100%',
+          color: TRgba.fromString(props.randommaincolor)
+            .getContrastTextColor()
+            .hex(),
+          opacity: 0.8,
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {currentGraphName}
+      </Typography>
+      <IconButton
+        sx={{ mr: 1 }}
+        size="small"
+        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+          event.stopPropagation();
+          // InterfaceController.setIsGraphSearchOpen(false);
+        }}
+        title="Create new playground"
+        className="menuItemButton"
+      >
+        <EditIcon
+          sx={{
+            fontSize: '20px',
+            // borderRadius: '2px 14px 14px 2px',
+            color: TRgba.fromString(props.randommaincolor)
+              .getContrastTextColor()
+              .hex(),
+            '&:hover': {
+              backgroundColor: TRgba.fromString(props.randommaincolor)
+                .darken(0.05)
+                .hex(),
+            },
+          }}
+        />
+      </IconButton>
+      <TextField
+        {...props}
+        hiddenLabel
+        inputRef={props.inputRef}
+        variant="filled"
+        placeholder={`Search playgrounds`}
+        InputProps={{
+          ...props.InputProps,
+          disableUnderline: true,
+          endAdornment: null,
+        }}
+        sx={{
+          margin: 0,
+          borderRadius: '2px',
+          fontSize: '16px',
+          backgroundColor: `${backgroundColor}`,
+          '&&& .MuiInputBase-root': {
+            backgroundColor: 'transparent',
+          },
+          '&&&& input': {
+            paddingBottom: '8px',
+            paddingTop: '9px',
+            color: TRgba.fromString(props.randommaincolor)
+              .getContrastTextColor()
+              .hex(),
+          },
+        }}
+      />
+      <Button
+        // color="secondary"
+        sx={{
+          px: 1,
+          borderRadius: '2px 14px 14px 2px',
+          color: TRgba.fromString(props.randommaincolor)
+            .getContrastTextColor()
+            .hex(),
+          '&:hover': {
+            backgroundColor: TRgba.fromString(props.randommaincolor)
+              .darken(0.05)
+              .hex(),
+          },
+        }}
+        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+          event.stopPropagation();
+          // InterfaceController.setIsGraphSearchOpen(false);
+        }}
+      >
+        New
+      </Button>
+    </Paper>
   );
 };
 
@@ -257,7 +380,7 @@ export const NodeSearchInput = (props) => {
 const findAndResetGroup = (
   suggestedNames: string[],
   arrayToFindIn: INodeSearch[],
-  groupName: string
+  groupName: string,
 ): INodeSearch[] => {
   const suggestedNodes: INodeSearch[] = [];
   suggestedNames.forEach((nodeName) => {
@@ -288,10 +411,11 @@ export const getNodes = (latest: INodeSearch[]): INodeSearch[] => {
         };
       })
       .sort((a, b) =>
-        a.name.localeCompare(b.name, 'en', { sensitivity: 'base' })
+        a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }),
       )
-      .sort((a, b) =>
-        a.group?.localeCompare(b.group, 'en', { sensitivity: 'base' })
+      .sort(
+        (a, b) =>
+          a.group?.localeCompare(b.group, 'en', { sensitivity: 'base' }),
       );
   }
 
@@ -308,7 +432,7 @@ export const getNodes = (latest: INodeSearch[]): INodeSearch[] => {
   const suggestedByType = findAndResetGroup(
     inOrOutputList,
     arrayWithGroupReset,
-    'Suggested by socket type'
+    'Suggested by socket type',
   );
 
   const preferredNodesList =
@@ -320,15 +444,15 @@ export const getNodes = (latest: INodeSearch[]): INodeSearch[] => {
   const suggestedByNode = findAndResetGroup(
     preferredNodesList,
     arrayWithGroupReset,
-    'Suggested by node'
+    'Suggested by node',
   );
 
   const combinedArray = latest.concat(
     suggestedByNode,
     suggestedByType,
     arrayWithGroupReset.filter(
-      (node) => !sourceSocket || node.hasInputs
-    ) as INodeSearch[]
+      (node) => !sourceSocket || node.hasInputs,
+    ) as INodeSearch[],
   );
 
   const included = {};

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -41,11 +41,14 @@ export const GraphSearchInput = (props) => {
   const backgroundColor = Color(props.randommaincolor).alpha(0.8);
 
   useEffect(() => {
-    PPStorage.getInstance()
-      .getGraphNameFromDB()
-      .then((name) => {
-        setCurrentGraphName(name);
-      });
+    const graphId = PPGraph.currentGraph?.id;
+    if (graphId) {
+      PPStorage.getInstance()
+        .getGraphNameFromDB(graphId)
+        .then((name) => {
+          setCurrentGraphName(name);
+        });
+    }
   }, [PPGraph.currentGraph?.id]);
 
   return (
@@ -92,7 +95,7 @@ export const GraphSearchInput = (props) => {
             <Button
               variant="text"
               size="small"
-              title="Logour from Github"
+              title="Log out from Github"
               onClick={() => {
                 const currentUrl = window.location.href;
                 window.location.href = `/logout?redirectUrl=${currentUrl}`;

--- a/src/utils/style.module.css
+++ b/src/utils/style.module.css
@@ -197,26 +197,18 @@
 
 .plugAndPlaygroundIcon {
   position: absolute;
-  left: 24px;
-  top: 24px;
+  left: 16px;
+  top: 16px;
   filter: drop-shadow(0px 0px 24px rgba(0, 0, 0, 0.15));
   user-select: none;
   border-radius: 32px;
   z-index: 10;
 }
 
-.userMenu {
-  position: absolute;
-  left: 24px;
-  top: 96px;
-  filter: drop-shadow(0px 0px 24px rgba(0, 0, 0, 0.15));
-  z-index: 10;
-}
-
 .graphSearch {
   position: absolute;
   left: 96px;
-  top: 36px;
+  top: 28px;
   filter: drop-shadow(0px 0px 24px rgba(94, 69, 69, 0.15));
   background: none;
   z-index: 10;


### PR DESCRIPTION
* updated the graph search header
  * now it shows the name of the selected graph
  * added save option
  * moved the share button inside the bar
  * added a create new/empty graph button
  * made it work for small screens
* added share option to context menu

<img width="1011" alt="Screenshot 2023-09-27 at 19 38 24" src="https://github.com/fakob/plug-and-play/assets/4619772/4c467f73-b867-4324-ba55-06a70b842676">
<img width="334" alt="Screenshot 2023-09-27 at 19 38 14" src="https://github.com/fakob/plug-and-play/assets/4619772/3c0f74d8-3a0b-4f37-b025-6905301cc219">