### PR TITLE
Add node browser

### DIFF
--- a/assets/examples/z debug missing nodes, sockets and links.ppgraph
+++ b/assets/examples/z debug missing nodes, sockets and links.ppgraph
@@ -2,11 +2,12 @@
   "version": 0.1,
   "graphSettings": {
     "showExecutionVisualisation": false,
+    "showNonPresentationNodes": true,
     "viewportCenterPosition": {
-      "x": -372.35794413775625,
-      "y": 259.7368354391414
+      "x": -884.9025385712275,
+      "y": 372.7129255311337
     },
-    "viewportScale": 0.4787386667753628
+    "viewportScale": 0.39860443755136743
   },
   "nodes": [
     {
@@ -16,22 +17,27 @@
       "x": -1246.4090086110548,
       "y": -446.3984493391838,
       "width": 160,
-      "minWidth": 160,
+      "height": 88,
       "socketArray": [
         {
           "socketType": "in",
           "name": "In",
-          "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 0,
-          "visible": true,
-          "isCustom": false
+          "visible": true
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Out",
           "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -47,22 +53,27 @@
       "x": -1260.9428427938815,
       "y": 301.5916692492709,
       "width": 160,
-      "minWidth": 160,
+      "height": 88,
       "socketArray": [
         {
           "socketType": "in",
           "name": "In",
-          "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
+          "dataType": "{\"class\":\"StringType\",\"type\":{}}",
           "data": "12",
-          "visible": true,
-          "isCustom": false
+          "visible": true
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Out",
           "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -78,29 +89,34 @@
       "x": -987.277614240068,
       "y": -470.32450814097865,
       "width": 160,
-      "minWidth": 160,
+      "height": 112,
       "socketArray": [
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
+        },
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":-10,\"maxValue\":10,\"stepSize\":0.01}}",
-          "visible": true,
-          "isCustom": false
+          "defaultData": 0,
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "Input 2",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":-10,\"maxValue\":10,\"stepSize\":0.01}}",
           "data": 10,
-          "visible": true,
-          "isCustom": false
+          "visible": true
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -116,43 +132,46 @@
       "x": -1004.3800774643175,
       "y": 254.0233794854247,
       "width": 160,
-      "minWidth": 160,
+      "height": 160,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Code",
           "dataType": "{\"class\":\"CodeType\",\"type\":{}}",
           "data": "//define your function here, node will adapt to inputs automatically\n(a, b) => {\n\treturn a * b;\n}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "a",
-          "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": true
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "b",
-          "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": true
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "defaultData": 0,
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "x",
           "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": true
+          "data": 0,
+          "visible": true
         },
         {
           "socketType": "out",
           "name": "OutData",
           "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
+        },
+        {
+          "socketType": "out",
+          "name": "Code",
+          "dataType": "{\"class\":\"CodeType\",\"type\":{}}",
+          "visible": false
         }
       ],
       "updateBehaviour": {
@@ -167,24 +186,28 @@
       "type": "Label",
       "x": -702.0915298294805,
       "y": -438.61634051152305,
-      "width": 128,
-      "height": 69,
-      "minWidth": 128,
+      "width": 160,
+      "height": 112,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "fontSize",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 32,
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
         },
         {
           "socketType": "in",
@@ -196,23 +219,41 @@
             "b": 204,
             "a": 1
           },
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "in",
           "name": "min-width",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 128,
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "fontSize-deleted",
+          "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
+          "defaultData": 0,
+          "visible": true
+        },
+        {
+          "socketType": "in",
+          "name": "fontSize-deleted2",
+          "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
+          "data": 0,
+          "visible": true
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -227,24 +268,28 @@
       "type": "Label",
       "x": -721.4765527247546,
       "y": 287.0033545562137,
-      "width": 128,
+      "width": 160,
       "height": 69,
-      "minWidth": 128,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "fontSize",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 32,
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
         },
         {
           "socketType": "in",
@@ -256,23 +301,27 @@
             "b": 204,
             "a": 1
           },
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "in",
           "name": "min-width",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 128,
-          "visible": false,
-          "isCustom": false
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -283,29 +332,58 @@
     },
     {
       "id": "young-firefox-23",
-      "name": "Note",
-      "type": "Note",
-      "x": -989.1987128488191,
-      "y": -654.4085946889322,
-      "width": 160,
-      "height": 160,
-      "minWidth": 160,
-      "minHeight": 160,
+      "name": "Label",
+      "type": "Label",
+      "x": -1092.3877461446675,
+      "y": -590.7321525804775,
+      "width": 325.5104166666667,
+      "height": 69,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
           "data": "Node does not exist",
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "fontSize",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
+          "data": 32,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "backgroundColor",
+          "dataType": "{\"class\":\"ColorType\",\"type\":{}}",
+          "data": {
+            "r": 84,
+            "g": 155,
+            "b": 224,
+            "a": 1
+          },
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -321,22 +399,27 @@
       "x": -1260.2935516264638,
       "y": -87.03921620535425,
       "width": 160,
-      "minWidth": 160,
+      "height": 88,
       "socketArray": [
         {
           "socketType": "in",
           "name": "In",
-          "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
+          "dataType": "{\"class\":\"StringType\",\"type\":{}}",
           "data": "9",
-          "visible": true,
-          "isCustom": false
+          "visible": true
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Out",
           "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -352,36 +435,60 @@
       "x": -1001.1621572554767,
       "y": -110.9652750071491,
       "width": 160,
-      "minWidth": 160,
+      "height": 184,
       "socketArray": [
         {
           "socketType": "in",
+          "name": "Code",
+          "dataType": "{\"class\":\"CodeType\",\"type\":{}}",
+          "data": "(Input1, Input2) => {\n\treturn Input1 + Input2;\n}",
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Input1",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "data": 1,
+          "visible": true
+        },
+        {
+          "socketType": "in",
+          "name": "Input2",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "data": 1,
+          "visible": true
+        },
+        {
+          "socketType": "in",
           "name": "Input",
-          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":-10,\"maxValue\":10,\"stepSize\":0.01}}",
-          "visible": true,
-          "isCustom": false
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "defaultData": 0,
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "Input 2",
-          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":-10,\"maxValue\":10,\"stepSize\":0.01}}",
-          "defaultData": 10,
-          "visible": true,
-          "isCustom": false
-        },        {
-          "socketType": "in",
-          "name": "Input 3",
-          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":-10,\"maxValue\":10,\"stepSize\":0.01}}",
-          "defaultData": 10,
-          "visible": true,
-          "isCustom": false
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "defaultData": 0,
+          "visible": true
+        },
+        {
+          "socketType": "out",
+          "name": "Result",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "visible": true
+        },
+        {
+          "socketType": "out",
+          "name": "Code",
+          "dataType": "{\"class\":\"CodeType\",\"type\":{}}",
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -396,24 +503,28 @@
       "type": "Label",
       "x": -715.9760728448891,
       "y": -79.2571073776935,
-      "width": 128,
+      "width": 160,
       "height": 69,
-      "minWidth": 128,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "fontSize",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 32,
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
         },
         {
           "socketType": "in",
@@ -425,23 +536,27 @@
             "b": 204,
             "a": 1
           },
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "in",
           "name": "min-width",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 128,
-          "visible": false,
-          "isCustom": false
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -452,29 +567,58 @@
     },
     {
       "id": "silent-ladybug-12",
-      "name": "Note",
-      "type": "Note",
-      "x": -1003.8307260392363,
-      "y": -276.60725089323796,
-      "width": 160,
-      "height": 160,
-      "minWidth": 160,
-      "minHeight": 160,
+      "name": "Label",
+      "type": "Label",
+      "x": -1092.3877461446675,
+      "y": -212.93080878478327,
+      "width": 378.8229166666667,
+      "height": 69,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
           "data": "Node has more sockets",
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "fontSize",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
+          "data": 32,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "backgroundColor",
+          "dataType": "{\"class\":\"ColorType\",\"type\":{}}",
+          "data": {
+            "r": 84,
+            "g": 155,
+            "b": 224,
+            "a": 1
+          },
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -485,29 +629,58 @@
     },
     {
       "id": "spicy-dingo-61",
-      "name": "Note",
-      "type": "Note",
-      "x": -1001.1416099770599,
-      "y": 85.83778871666937,
-      "width": 160,
-      "height": 160,
-      "minWidth": 160,
-      "minHeight": 160,
+      "name": "Label",
+      "type": "Label",
+      "x": -1092.3877461446675,
+      "y": 149.51423082512406,
+      "width": 492.6510416666667,
+      "height": 69,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
           "data": "Custom node has more sockets",
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "fontSize",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
+          "data": 32,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "backgroundColor",
+          "dataType": "{\"class\":\"ColorType\",\"type\":{}}",
+          "data": {
+            "r": 84,
+            "g": 155,
+            "b": 224,
+            "a": 1
+          },
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -523,22 +696,27 @@
       "x": -1263.9902476644545,
       "y": 1081.6848851463317,
       "width": 160,
-      "minWidth": 160,
+      "height": 88,
       "socketArray": [
         {
           "socketType": "in",
           "name": "In",
-          "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
+          "dataType": "{\"class\":\"StringType\",\"type\":{}}",
           "data": "12",
-          "visible": true,
-          "isCustom": false
+          "visible": true
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Out",
           "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -554,29 +732,40 @@
       "x": -1007.427482334891,
       "y": 1034.1165953824852,
       "width": 160,
-      "minWidth": 160,
+      "height": 136,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Code",
           "dataType": "{\"class\":\"CodeType\",\"type\":{}}",
           "data": "//define your function here, node will adapt to inputs automatically\n(a, b) => {\n\treturn a * b;\n}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
+        },
+        {
+          "socketType": "in",
+          "name": "a",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "defaultData": 0,
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "b",
-          "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": true
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "defaultData": 0,
+          "visible": true
         },
         {
           "socketType": "out",
           "name": "OutData",
           "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
+        },
+        {
+          "socketType": "out",
+          "name": "Code",
+          "dataType": "{\"class\":\"CodeType\",\"type\":{}}",
+          "visible": false
         }
       ],
       "updateBehaviour": {
@@ -591,24 +780,28 @@
       "type": "Label",
       "x": -724.5239575953274,
       "y": 1067.0965704532744,
-      "width": 128,
+      "width": 160,
       "height": 69,
-      "minWidth": 128,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "fontSize",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 32,
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
         },
         {
           "socketType": "in",
@@ -620,23 +813,27 @@
             "b": 204,
             "a": 1
           },
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "in",
           "name": "min-width",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 128,
-          "visible": false,
-          "isCustom": false
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -652,22 +849,27 @@
       "x": -1263.3409564970368,
       "y": 693.0539996917064,
       "width": 160,
-      "minWidth": 160,
+      "height": 88,
       "socketArray": [
         {
           "socketType": "in",
           "name": "In",
-          "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
+          "dataType": "{\"class\":\"StringType\",\"type\":{}}",
           "data": "9",
-          "visible": true,
-          "isCustom": false
+          "visible": true
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Out",
           "dataType": "{\"class\":\"AnyType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -683,21 +885,60 @@
       "x": -1004.2095621260505,
       "y": 669.1279408899115,
       "width": 160,
-      "minWidth": 160,
+      "height": 184,
       "socketArray": [
         {
           "socketType": "in",
+          "name": "Code",
+          "dataType": "{\"class\":\"CodeType\",\"type\":{}}",
+          "data": "(Input1, Input2) => {\n\treturn Input1 + Input2;\n}",
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Input1",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "data": 1,
+          "visible": true
+        },
+        {
+          "socketType": "in",
+          "name": "Input2",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "data": 1,
+          "visible": true
+        },
+        {
+          "socketType": "in",
           "name": "Input",
-          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":-10,\"maxValue\":10,\"stepSize\":0.01}}",
-          "visible": true,
-          "isCustom": false
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "defaultData": 0,
+          "visible": true
+        },
+        {
+          "socketType": "in",
+          "name": "Input 2",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "defaultData": 0,
+          "visible": true
+        },
+        {
+          "socketType": "out",
+          "name": "Result",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "visible": true
+        },
+        {
+          "socketType": "out",
+          "name": "Code",
+          "dataType": "{\"class\":\"CodeType\",\"type\":{}}",
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -712,24 +953,28 @@
       "type": "Label",
       "x": -719.0234777154619,
       "y": 700.8361085193671,
-      "width": 128,
+      "width": 160,
       "height": 69,
-      "minWidth": 128,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         },
         {
           "socketType": "in",
           "name": "fontSize",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 32,
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
         },
         {
           "socketType": "in",
@@ -741,23 +986,27 @@
             "b": 204,
             "a": 1
           },
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "in",
           "name": "min-width",
           "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
           "data": 128,
-          "visible": false,
-          "isCustom": false
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -768,29 +1017,58 @@
     },
     {
       "id": "breezy-sloth-4",
-      "name": "Note",
-      "type": "Note",
-      "x": -1006.8781309098099,
-      "y": 503.4859650038227,
-      "width": 160,
-      "height": 160,
-      "minWidth": 160,
-      "minHeight": 160,
+      "name": "Label",
+      "type": "Label",
+      "x": -1092.3877461446675,
+      "y": 567.1624071122774,
+      "width": 362.8229166666667,
+      "height": 69,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
           "data": "Node has less sockets",
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "fontSize",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
+          "data": 32,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "backgroundColor",
+          "dataType": "{\"class\":\"ColorType\",\"type\":{}}",
+          "data": {
+            "r": 84,
+            "g": 155,
+            "b": 224,
+            "a": 1
+          },
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -801,29 +1079,58 @@
     },
     {
       "id": "quiet-parrot-19",
-      "name": "Note",
-      "type": "Note",
-      "x": -1004.1890148476336,
-      "y": 865.93100461373,
-      "width": 160,
-      "height": 160,
-      "minWidth": 160,
-      "minHeight": 160,
+      "name": "Label",
+      "type": "Label",
+      "x": -1092.3877461446675,
+      "y": 929.6074467221847,
+      "width": 476.6510416666667,
+      "height": 69,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
           "data": "Custom node has less sockets",
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "fontSize",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
+          "data": 32,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "backgroundColor",
+          "dataType": "{\"class\":\"ColorType\",\"type\":{}}",
+          "data": {
+            "r": 84,
+            "g": 155,
+            "b": 224,
+            "a": 1
+          },
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -834,29 +1141,58 @@
     },
     {
       "id": "hard-rat-76",
-      "name": "Note",
-      "type": "Note",
-      "x": -1010.7604874500266,
-      "y": 1227.4815866881877,
-      "width": 160,
-      "height": 160,
-      "minWidth": 160,
-      "minHeight": 160,
+      "name": "Label",
+      "type": "Label",
+      "x": -1092.3877461446675,
+      "y": 1291.1580287966424,
+      "width": 574.5729166666666,
+      "height": 69,
       "socketArray": [
         {
           "socketType": "in",
           "name": "Input",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
           "data": "Links between deleted nodes/sockets",
-          "visible": false,
-          "isCustom": false
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "fontSize",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":1,\"maxValue\":100,\"stepSize\":0.01}}",
+          "data": 32,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Width",
+          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":true,\"minValue\":0,\"maxValue\":1280,\"stepSize\":0.01}}",
+          "data": 0,
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "backgroundColor",
+          "dataType": "{\"class\":\"ColorType\",\"type\":{}}",
+          "data": {
+            "r": 84,
+            "g": 155,
+            "b": 224,
+            "a": 1
+          },
+          "visible": false
+        },
+        {
+          "socketType": "in",
+          "name": "Meta",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "data": {},
+          "visible": false
         },
         {
           "socketType": "out",
           "name": "Output",
           "dataType": "{\"class\":\"StringType\",\"type\":{}}",
-          "visible": true,
-          "isCustom": false
+          "visible": true
         }
       ],
       "updateBehaviour": {
@@ -868,144 +1204,109 @@
   ],
   "links": [
     {
-      "id": 0,
+      "id": "302ef455-11fd-4435-92e9-60ec4aa3d02b",
       "sourceNodeId": "purple-firefox-94",
       "sourceSocketName": "Out",
       "targetNodeId": "chilly-cow-78",
       "targetSocketName": "Input"
     },
     {
-      "id": 1,
+      "id": "c4b87eb8-13ab-4dc3-9732-575673659adf",
       "sourceNodeId": "rude-sloth-39",
       "sourceSocketName": "Out",
       "targetNodeId": "fuzzy-badger-84",
       "targetSocketName": "a"
     },
     {
-      "id": 2,
+      "id": "42bf47c0-1459-45e6-86d2-4116736bfdac",
+      "sourceNodeId": "rude-sloth-39",
+      "sourceSocketName": "Out",
+      "targetNodeId": "fuzzy-badger-84",
+      "targetSocketName": "b"
+    },
+    {
+      "id": "0084d82d-2ff2-4201-8d4c-50acc0831277",
       "sourceNodeId": "chilly-cow-78",
       "sourceSocketName": "Output",
       "targetNodeId": "empty-chicken-87",
       "targetSocketName": "Input"
     },
     {
-      "id": 3,
-      "sourceNodeId": "fuzzy-badger-84",
-      "sourceSocketName": "OutData",
-      "targetNodeId": "modern-squid-29",
-      "targetSocketName": "Input"
-    },
-    {
-      "id": 4,
-      "sourceNodeId": "rude-sloth-39",
-      "sourceSocketName": "Out",
-      "targetNodeId": "fuzzy-badger-84",
-      "targetSocketName": "b"
-    },
-    {
-      "id": 5,
-      "sourceNodeId": "splendid-robin-85",
-      "sourceSocketName": "Out",
-      "targetNodeId": "good-duck-74",
-      "targetSocketName": "Input"
-    },
-    {
-      "id": 6,
-      "sourceNodeId": "good-duck-74",
-      "sourceSocketName": "Output",
-      "targetNodeId": "pink-wombat-80",
-      "targetSocketName": "Input"
-    },
-    {
-      "id": 7,
-      "sourceNodeId": "helpless-treefrog-27",
-      "sourceSocketName": "Out",
-      "targetNodeId": "light-termite-31",
-      "targetSocketName": "a"
-    },
-    {
-      "id": 8,
-      "sourceNodeId": "helpless-treefrog-27",
-      "sourceSocketName": "Out",
-      "targetNodeId": "light-termite-31",
-      "targetSocketName": "b"
-    },
-    {
-      "id": 9,
-      "sourceNodeId": "light-termite-31",
-      "sourceSocketName": "OutData",
-      "targetNodeId": "tough-earwig-11",
-      "targetSocketName": "Input"
-    },
-    {
-      "id": 10,
-      "sourceNodeId": "proud-monkey-32",
-      "sourceSocketName": "Out",
-      "targetNodeId": "spotty-gecko-55",
-      "targetSocketName": "Input"
-    },
-    {
-      "id": 11,
-      "sourceNodeId": "spotty-gecko-55",
-      "sourceSocketName": "Output",
-      "targetNodeId": "evil-stingray-46",
-      "targetSocketName": "Input"
-    },
-    {
-      "id": 12,
-      "sourceNodeId": "proud-monkey-32",
-      "sourceSocketName": "Out",
-      "targetNodeId": "spotty-gecko-55",
-      "targetSocketName": "Input 2"
-    },
-    {
-      "id": 13,
-      "sourceNodeId": "splendid-robin-85",
-      "sourceSocketName": "Out",
-      "targetNodeId": "good-duck-74",
-      "targetSocketName": "Input 2"
-    },
-    {
-      "id": 14,
-      "sourceNodeId": "splendid-robin-85-deleted",
-      "sourceSocketName": "Out",
-      "targetNodeId": "good-duck-74",
-      "targetSocketName": "Input 2"
-    },
-    {
-      "id": 16,
-      "sourceNodeId": "splendid-robin-85",
-      "sourceSocketName": "Out",
-      "targetNodeId": "good-duck-74-deleted",
-      "targetSocketName": "Input 2"
-    },
-    {
-      "id": 17,
-      "sourceNodeId": "splendid-robin-85-deleted2",
-      "sourceSocketName": "Out",
-      "targetNodeId": "good-duck-74-deleted",
-      "targetSocketName": "Input 2"
-    },
-    {
-      "id": 18,
-      "sourceNodeId": "purple-firefox-94",
-      "sourceSocketName": "Out-deleted",
-      "targetNodeId": "empty-chicken-87",
-      "targetSocketName": "fontSize"
-    },
-    {
-      "id": 19,
+      "id": "27a75d5e-4ba3-4ade-97dc-c9d7f643b16a",
       "sourceNodeId": "purple-firefox-94",
       "sourceSocketName": "Out",
       "targetNodeId": "empty-chicken-87",
       "targetSocketName": "fontSize-deleted"
     },
     {
-      "id": 20,
-      "sourceNodeId": "purple-firefox-94",
-      "sourceSocketName": "Out-deleted",
-      "targetNodeId": "empty-chicken-87",
-      "targetSocketName": "fontSize-deleted2"
+      "id": "1168ab56-c55c-4efb-8862-d346a1271cff",
+      "sourceNodeId": "fuzzy-badger-84",
+      "sourceSocketName": "OutData",
+      "targetNodeId": "modern-squid-29",
+      "targetSocketName": "Input"
+    },
+    {
+      "id": "b5329d6f-84ba-4bd1-8282-4ecc88f38af8",
+      "sourceNodeId": "splendid-robin-85",
+      "sourceSocketName": "Out",
+      "targetNodeId": "good-duck-74",
+      "targetSocketName": "Input"
+    },
+    {
+      "id": "b60c623b-5476-43b0-90fc-c4b413bf543d",
+      "sourceNodeId": "splendid-robin-85",
+      "sourceSocketName": "Out",
+      "targetNodeId": "good-duck-74",
+      "targetSocketName": "Input 2"
+    },
+    {
+      "id": "55e30929-c248-4a0a-831f-868bd6a3504f",
+      "sourceNodeId": "good-duck-74",
+      "sourceSocketName": "Output",
+      "targetNodeId": "pink-wombat-80",
+      "targetSocketName": "Input"
+    },
+    {
+      "id": "772e64e2-b0aa-44cc-908f-cc10d59a48de",
+      "sourceNodeId": "helpless-treefrog-27",
+      "sourceSocketName": "Out",
+      "targetNodeId": "light-termite-31",
+      "targetSocketName": "a"
+    },
+    {
+      "id": "4db8fade-6063-47ca-80d5-3abba3de6dc4",
+      "sourceNodeId": "helpless-treefrog-27",
+      "sourceSocketName": "Out",
+      "targetNodeId": "light-termite-31",
+      "targetSocketName": "b"
+    },
+    {
+      "id": "21774454-ac54-4de0-86bb-b54613a9b60f",
+      "sourceNodeId": "light-termite-31",
+      "sourceSocketName": "OutData",
+      "targetNodeId": "tough-earwig-11",
+      "targetSocketName": "Input"
+    },
+    {
+      "id": "e7268c59-4106-4d67-a656-6646e1ccdc07",
+      "sourceNodeId": "proud-monkey-32",
+      "sourceSocketName": "Out",
+      "targetNodeId": "spotty-gecko-55",
+      "targetSocketName": "Input"
+    },
+    {
+      "id": "860d4826-a994-431c-a581-419646bb1691",
+      "sourceNodeId": "proud-monkey-32",
+      "sourceSocketName": "Out",
+      "targetNodeId": "spotty-gecko-55",
+      "targetSocketName": "Input 2"
+    },
+    {
+      "id": "9111c3e8-8070-4dc2-9c39-4f821552354f",
+      "sourceNodeId": "spotty-gecko-55",
+      "sourceSocketName": "Output",
+      "targetNodeId": "evil-stingray-46",
+      "targetSocketName": "Input"
     }
   ]
 }

--- a/src/GraphInspectorContainer.tsx
+++ b/src/GraphInspectorContainer.tsx
@@ -1,21 +1,12 @@
-import React, { useEffect, useRef } from 'react';
-import {
-  Box,
-  IconButton,
-  Stack,
-  TextField,
-  ThemeProvider,
-  Typography,
-} from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
+import React, { useEffect } from 'react';
+import { Box, Stack, ThemeProvider, Typography } from '@mui/material';
 import Color from 'color';
 import styles from './utils/style.module.css';
 import PPNode from './classes/NodeClass';
-import Socket from './classes/SocketClass';
 import { NodeArrayContainer } from './NodeArrayContainer';
 import { COLOR_WHITE_TEXT, COLOR_DARK, customTheme } from './utils/constants';
 
-function InspectorHeaderReadOnly(props) {
+function GraphInspectorHeader(props) {
   return (
     <Box
       id="inspector-header-readonly"
@@ -38,97 +29,9 @@ function InspectorHeaderReadOnly(props) {
             py: 0.5,
           }}
         >
-          {`${props.selectedNodes.length} nodes selected`}
+          Graph inspector
         </Typography>
       </Box>
-    </Box>
-  );
-}
-
-function InspectorHeader(props) {
-  const textInput = useRef(null);
-
-  return (
-    <Box
-      id="inspector-header"
-      sx={{
-        color: `${
-          Color(props.randomMainColor).isDark() ? COLOR_WHITE_TEXT : COLOR_DARK
-        }`,
-      }}
-    >
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}
-      >
-        <TextField
-          hiddenLabel
-          inputRef={textInput}
-          disabled={props.selectedNodes.length !== 1}
-          onChange={(event) => {
-            const value = event.target.value;
-            props.selectedNodes[0].nodeName = value;
-            props.setNodeName(value);
-          }}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault();
-              textInput.current.blur();
-            }
-          }}
-          value={props.nodeName}
-          sx={{
-            width: '100%',
-            '&& .MuiOutlinedInput-root': {
-              '& fieldset': {
-                border: 0,
-              },
-              '& input': {
-                color: `${
-                  Color(props.randomMainColor).isDark()
-                    ? COLOR_WHITE_TEXT
-                    : COLOR_DARK
-                }`,
-                padding: '4px 8px',
-              },
-              '& input:hover': {
-                backgroundColor: Color(props.randomMainColor).alpha(0.5).hexa(),
-              },
-              '& input:focus': {
-                boxShadow: `0 0 0 1px ${props.randomMainColor}`,
-                backgroundColor: Color(props.randomMainColor).alpha(0.5).hexa(),
-              },
-            },
-          }}
-        />
-        <IconButton
-          title="Edit node name"
-          color="secondary"
-          size="small"
-          onClick={() => {
-            setTimeout(() => {
-              textInput.current.focus();
-            }, 100);
-          }}
-        >
-          <EditIcon fontSize="inherit" />
-        </IconButton>
-      </Box>
-      {props.selectedNodes[0].type !== props.nodeName && (
-        <Typography
-          sx={{
-            opacity: 0.5,
-            fontSize: '10px',
-            wordBreak: 'break-all',
-            pl: 1,
-          }}
-        >
-          {props.selectedNodes[0].type}
-        </Typography>
-      )}
     </Box>
   );
 }
@@ -163,21 +66,12 @@ const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
           paddingRight: 0,
         }}
       >
-        {props.selectedNodes.length === 1 ? (
-          <InspectorHeader
-            nodeName={nodeName}
-            setNodeName={setNodeName}
-            selectedNodes={props.selectedNodes}
-            randomMainColor={props.randomMainColor}
-          />
-        ) : (
-          <InspectorHeaderReadOnly
-            nodeName={nodeName}
-            setNodeName={setNodeName}
-            selectedNodes={props.selectedNodes}
-            randomMainColor={props.randomMainColor}
-          />
-        )}
+        <GraphInspectorHeader
+          nodeName={nodeName}
+          setNodeName={setNodeName}
+          selectedNodes={props.selectedNodes}
+          randomMainColor={props.randomMainColor}
+        />
         <NodeArrayContainer
           selectedNodes={props.selectedNodes}
           randomMainColor={props.randomMainColor}

--- a/src/GraphInspectorContainer.tsx
+++ b/src/GraphInspectorContainer.tsx
@@ -41,6 +41,8 @@ type InspectorContainerProps = {
   randomMainColor: string;
   filter: string;
   setFilter: React.Dispatch<React.SetStateAction<string>>;
+  filterText: string;
+  setFilterText: React.Dispatch<React.SetStateAction<string>>;
 };
 
 const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
@@ -77,6 +79,8 @@ const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
           randomMainColor={props.randomMainColor}
           filter={props.filter}
           setFilter={props.setFilter}
+          filterText={props.filterText}
+          setFilterText={props.setFilterText}
         />
       </Stack>
     </ThemeProvider>

--- a/src/GraphInspectorContainer.tsx
+++ b/src/GraphInspectorContainer.tsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  Box,
+  IconButton,
+  Stack,
+  TextField,
+  ThemeProvider,
+  Typography,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import Color from 'color';
+import styles from './utils/style.module.css';
+import PPNode from './classes/NodeClass';
+import Socket from './classes/SocketClass';
+import { NodeArrayContainer } from './NodeArrayContainer';
+import { COLOR_WHITE_TEXT, COLOR_DARK, customTheme } from './utils/constants';
+
+function InspectorHeaderReadOnly(props) {
+  return (
+    <Box
+      id="inspector-header-readonly"
+      sx={{
+        color: `${
+          Color(props.randomMainColor).isDark() ? COLOR_WHITE_TEXT : COLOR_DARK
+        }`,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          sx={{
+            pl: 1,
+            py: 0.5,
+          }}
+        >
+          {`${props.selectedNodes.length} nodes selected`}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+function InspectorHeader(props) {
+  const textInput = useRef(null);
+
+  return (
+    <Box
+      id="inspector-header"
+      sx={{
+        color: `${
+          Color(props.randomMainColor).isDark() ? COLOR_WHITE_TEXT : COLOR_DARK
+        }`,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <TextField
+          hiddenLabel
+          inputRef={textInput}
+          disabled={props.selectedNodes.length !== 1}
+          onChange={(event) => {
+            const value = event.target.value;
+            props.selectedNodes[0].nodeName = value;
+            props.setNodeName(value);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              textInput.current.blur();
+            }
+          }}
+          value={props.nodeName}
+          sx={{
+            width: '100%',
+            '&& .MuiOutlinedInput-root': {
+              '& fieldset': {
+                border: 0,
+              },
+              '& input': {
+                color: `${
+                  Color(props.randomMainColor).isDark()
+                    ? COLOR_WHITE_TEXT
+                    : COLOR_DARK
+                }`,
+                padding: '4px 8px',
+              },
+              '& input:hover': {
+                backgroundColor: Color(props.randomMainColor).alpha(0.5).hexa(),
+              },
+              '& input:focus': {
+                boxShadow: `0 0 0 1px ${props.randomMainColor}`,
+                backgroundColor: Color(props.randomMainColor).alpha(0.5).hexa(),
+              },
+            },
+          }}
+        />
+        <IconButton
+          title="Edit node name"
+          color="secondary"
+          size="small"
+          onClick={() => {
+            setTimeout(() => {
+              textInput.current.focus();
+            }, 100);
+          }}
+        >
+          <EditIcon fontSize="inherit" />
+        </IconButton>
+      </Box>
+      {props.selectedNodes[0].type !== props.nodeName && (
+        <Typography
+          sx={{
+            opacity: 0.5,
+            fontSize: '10px',
+            wordBreak: 'break-all',
+            pl: 1,
+          }}
+        >
+          {props.selectedNodes[0].type}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+type InspectorContainerProps = {
+  selectedNodes: PPNode[];
+  randomMainColor: string;
+  filter: string;
+  setFilter: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
+  props,
+) => {
+  const [nodeName, setNodeName] = React.useState(
+    props.selectedNodes?.[0]?.name,
+  );
+
+  useEffect(() => {
+    setNodeName(props.selectedNodes?.[0]?.name);
+  }, [props.selectedNodes]);
+
+  return (
+    <ThemeProvider theme={customTheme}>
+      <Stack
+        id="inspector-container"
+        spacing={1}
+        className={`${styles.inspectorContainer}`}
+        sx={{
+          fontFamily: "'Roboto', 'Helvetica', 'Arial', 'sans-serif'",
+          height: '100%',
+          paddingRight: 0,
+        }}
+      >
+        {props.selectedNodes.length === 1 ? (
+          <InspectorHeader
+            nodeName={nodeName}
+            setNodeName={setNodeName}
+            selectedNodes={props.selectedNodes}
+            randomMainColor={props.randomMainColor}
+          />
+        ) : (
+          <InspectorHeaderReadOnly
+            nodeName={nodeName}
+            setNodeName={setNodeName}
+            selectedNodes={props.selectedNodes}
+            randomMainColor={props.randomMainColor}
+          />
+        )}
+        <NodeArrayContainer
+          selectedNodes={props.selectedNodes}
+          randomMainColor={props.randomMainColor}
+          filter={props.filter}
+          setFilter={props.setFilter}
+        />
+      </Stack>
+    </ThemeProvider>
+  );
+};
+
+export default InspectorContainer;

--- a/src/GraphInspectorContainer.tsx
+++ b/src/GraphInspectorContainer.tsx
@@ -50,9 +50,7 @@ type GraphInspectorContainerProps = {
 const GraphInspectorContainer: React.FunctionComponent<
   GraphInspectorContainerProps
 > = (props) => {
-  const [graphName, setGraphName] = React.useState(
-    props.selectedNodes?.[0]?.name,
-  );
+  const [graphName, setGraphName] = React.useState('');
 
   useEffect(() => {
     const graphId = PPGraph.currentGraph?.id;
@@ -84,6 +82,7 @@ const GraphInspectorContainer: React.FunctionComponent<
         />
         <NodeArrayContainer
           graphName={graphName}
+          graphId={PPGraph.currentGraph?.id}
           selectedNodes={props.selectedNodes}
           randomMainColor={props.randomMainColor}
           filter={props.filter}

--- a/src/GraphInspectorContainer.tsx
+++ b/src/GraphInspectorContainer.tsx
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react';
 import { Box, Stack, ThemeProvider, Typography } from '@mui/material';
 import Color from 'color';
 import styles from './utils/style.module.css';
+import PPStorage from './PPStorage';
+import PPGraph from './classes/GraphClass';
 import PPNode from './classes/NodeClass';
 import { NodeArrayContainer } from './NodeArrayContainer';
 import { COLOR_WHITE_TEXT, COLOR_DARK, customTheme } from './utils/constants';
@@ -29,14 +31,14 @@ function GraphInspectorHeader(props) {
             py: 0.5,
           }}
         >
-          Graph inspector
+          {props.graphName}
         </Typography>
       </Box>
     </Box>
   );
 }
 
-type InspectorContainerProps = {
+type GraphInspectorContainerProps = {
   selectedNodes: PPNode[];
   randomMainColor: string;
   filter: string;
@@ -45,16 +47,24 @@ type InspectorContainerProps = {
   setFilterText: React.Dispatch<React.SetStateAction<string>>;
 };
 
-const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
-  props,
-) => {
-  const [nodeName, setNodeName] = React.useState(
+const GraphInspectorContainer: React.FunctionComponent<
+  GraphInspectorContainerProps
+> = (props) => {
+  const [graphName, setGraphName] = React.useState(
     props.selectedNodes?.[0]?.name,
   );
 
   useEffect(() => {
-    setNodeName(props.selectedNodes?.[0]?.name);
-  }, [props.selectedNodes]);
+    const graphId = PPGraph.currentGraph?.id;
+    if (graphId) {
+      PPStorage.getInstance()
+        .getGraphNameFromDB(graphId)
+        .then((name) => {
+          console.log(name);
+          setGraphName(name);
+        });
+    }
+  }, [PPGraph.currentGraph?.id]);
 
   return (
     <ThemeProvider theme={customTheme}>
@@ -69,12 +79,11 @@ const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
         }}
       >
         <GraphInspectorHeader
-          nodeName={nodeName}
-          setNodeName={setNodeName}
-          selectedNodes={props.selectedNodes}
+          graphName={graphName}
           randomMainColor={props.randomMainColor}
         />
         <NodeArrayContainer
+          graphName={graphName}
           selectedNodes={props.selectedNodes}
           randomMainColor={props.randomMainColor}
           filter={props.filter}
@@ -87,4 +96,4 @@ const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
   );
 };
 
-export default InspectorContainer;
+export default GraphInspectorContainer;

--- a/src/InspectorContainer.tsx
+++ b/src/InspectorContainer.tsx
@@ -161,7 +161,7 @@ function InspectorHeader(props) {
           <EditIcon fontSize="inherit" />
         </IconButton>
       </Box>
-      {props.selectedNodes[0].type !== props.nodeName && (
+      {props.selectedNodes[0].name !== props.selectedNodes[0].getName() && (
         <Typography
           sx={{
             opacity: 0.5,
@@ -170,7 +170,7 @@ function InspectorHeader(props) {
             pl: 1,
           }}
         >
-          {props.selectedNodes[0].type}
+          {props.selectedNodes[0].getName()}
         </Typography>
       )}
     </Box>
@@ -188,9 +188,7 @@ type InspectorContainerProps = {
 const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
   props,
 ) => {
-  const [nodeName, setNodeName] = React.useState(
-    props.selectedNodes?.[0]?.name,
-  );
+  const [nodeName, setNodeName] = React.useState('');
 
   useEffect(() => {
     setNodeName(props.selectedNodes?.[0]?.name);

--- a/src/InspectorContainer.tsx
+++ b/src/InspectorContainer.tsx
@@ -17,59 +17,19 @@ import Socket from './classes/SocketClass';
 import { PropertyArrayContainer } from './PropertyArrayContainer';
 import { COLOR_WHITE_TEXT, COLOR_DARK, customTheme } from './utils/constants';
 
-function InspectorHeaderReadOnly(props) {
-  return (
-    <Box
-      id="inspector-header-readonly"
-      sx={{
-        color: `${
-          Color(props.randomMainColor).isDark() ? COLOR_WHITE_TEXT : COLOR_DARK
-        }`,
-      }}
-    >
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}
-      >
-        <IconButton
-          title="Unselect nodes"
-          color="secondary"
-          size="small"
-          sx={{
-            color: `${
-              Color(props.randomMainColor).isDark()
-                ? COLOR_WHITE_TEXT
-                : COLOR_DARK
-            }`,
-          }}
-          onClick={() => {
-            PPGraph.currentGraph.selection.deselectAllNodes();
-          }}
-        >
-          <ArrowBackIcon fontSize="inherit" />
-        </IconButton>
-        <Typography
-          sx={{
-            pl: 1,
-            py: 0.5,
-          }}
-        >
-          {`${props.selectedNodes.length} nodes selected`}
-        </Typography>
-      </Box>
-    </Box>
-  );
-}
-
 function InspectorHeader(props) {
+  const [nodeName, setNodeName] = React.useState('');
   const textInput = useRef(null);
+  const isEditable = props.isEditable;
+  const originalName = props.selectedNodes[0].getName();
+
+  useEffect(() => {
+    setNodeName(props.selectedNodes?.[0]?.name);
+  }, [props.selectedNodes]);
 
   return (
     <Box
-      id="inspector-header"
+      id={isEditable ? 'inspector-header' : 'inspector-header-readonly'}
       sx={{
         color: `${
           Color(props.randomMainColor).isDark() ? COLOR_WHITE_TEXT : COLOR_DARK
@@ -100,68 +60,86 @@ function InspectorHeader(props) {
         >
           <ArrowBackIcon fontSize="inherit" />
         </IconButton>
-        <TextField
-          title={props.selectedNodes[0].id}
-          hiddenLabel
-          inputRef={textInput}
-          disabled={props.selectedNodes.length !== 1}
-          onChange={(event) => {
-            const value = event.target.value;
-            props.selectedNodes[0].nodeName = value;
-            props.setNodeName(value);
-          }}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault();
-              textInput.current.blur();
-            }
-          }}
-          value={props.nodeName}
-          sx={{
-            width: '100%',
-            '&& .MuiOutlinedInput-root': {
-              '& fieldset': {
-                border: 0,
-              },
-              '& input': {
+        {props.isEditable ? (
+          <>
+            <TextField
+              title={props.selectedNodes[0].id}
+              hiddenLabel
+              inputRef={textInput}
+              disabled={props.selectedNodes.length !== 1}
+              onChange={(event) => {
+                const value = event.target.value;
+                props.selectedNodes[0].nodeName = value;
+                setNodeName(value);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  textInput.current.blur();
+                }
+              }}
+              value={nodeName}
+              sx={{
+                width: '100%',
+                '&& .MuiOutlinedInput-root': {
+                  '& fieldset': {
+                    border: 0,
+                  },
+                  '& input': {
+                    color: `${
+                      Color(props.randomMainColor).isDark()
+                        ? COLOR_WHITE_TEXT
+                        : COLOR_DARK
+                    }`,
+                    padding: '4px 8px',
+                  },
+                  '& input:hover': {
+                    backgroundColor: Color(props.randomMainColor)
+                      .alpha(0.5)
+                      .hexa(),
+                  },
+                  '& input:focus': {
+                    boxShadow: `0 0 0 1px ${props.randomMainColor}`,
+                    backgroundColor: Color(props.randomMainColor)
+                      .alpha(0.5)
+                      .hexa(),
+                  },
+                },
+              }}
+            />
+            <IconButton
+              title="Edit node name"
+              color="secondary"
+              size="small"
+              sx={{
                 color: `${
                   Color(props.randomMainColor).isDark()
                     ? COLOR_WHITE_TEXT
                     : COLOR_DARK
                 }`,
-                padding: '4px 8px',
-              },
-              '& input:hover': {
-                backgroundColor: Color(props.randomMainColor).alpha(0.5).hexa(),
-              },
-              '& input:focus': {
-                boxShadow: `0 0 0 1px ${props.randomMainColor}`,
-                backgroundColor: Color(props.randomMainColor).alpha(0.5).hexa(),
-              },
-            },
-          }}
-        />
-        <IconButton
-          title="Edit node name"
-          color="secondary"
-          size="small"
-          sx={{
-            color: `${
-              Color(props.randomMainColor).isDark()
-                ? COLOR_WHITE_TEXT
-                : COLOR_DARK
-            }`,
-          }}
-          onClick={() => {
-            setTimeout(() => {
-              textInput.current.focus();
-            }, 100);
-          }}
-        >
-          <EditIcon fontSize="inherit" />
-        </IconButton>
+              }}
+              onClick={() => {
+                setTimeout(() => {
+                  textInput.current.focus();
+                }, 100);
+              }}
+            >
+              <EditIcon fontSize="inherit" />
+            </IconButton>
+          </>
+        ) : (
+          <Typography
+            sx={{
+              pl: 1,
+              py: 0.5,
+              width: '100%',
+            }}
+          >
+            {`${props.selectedNodes.length} nodes selected`}
+          </Typography>
+        )}
       </Box>
-      {props.selectedNodes[0].name !== props.selectedNodes[0].getName() && (
+      {props.isEditable && (
         <Typography
           sx={{
             opacity: 0.5,
@@ -170,7 +148,7 @@ function InspectorHeader(props) {
             pl: 1,
           }}
         >
-          {props.selectedNodes[0].getName()}
+          {originalName}
         </Typography>
       )}
     </Box>
@@ -188,12 +166,6 @@ type InspectorContainerProps = {
 const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
   props,
 ) => {
-  const [nodeName, setNodeName] = React.useState('');
-
-  useEffect(() => {
-    setNodeName(props.selectedNodes?.[0]?.name);
-  }, [props.selectedNodes]);
-
   return (
     <ThemeProvider theme={customTheme}>
       <Stack
@@ -208,15 +180,13 @@ const InspectorContainer: React.FunctionComponent<InspectorContainerProps> = (
       >
         {props.selectedNodes.length === 1 ? (
           <InspectorHeader
-            nodeName={nodeName}
-            setNodeName={setNodeName}
+            isEditable={true}
             selectedNodes={props.selectedNodes}
             randomMainColor={props.randomMainColor}
           />
         ) : (
-          <InspectorHeaderReadOnly
-            nodeName={nodeName}
-            setNodeName={setNodeName}
+          <InspectorHeader
+            isEditable={false}
             selectedNodes={props.selectedNodes}
             randomMainColor={props.randomMainColor}
           />

--- a/src/InspectorContainer.tsx
+++ b/src/InspectorContainer.tsx
@@ -7,9 +7,11 @@ import {
   ThemeProvider,
   Typography,
 } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import EditIcon from '@mui/icons-material/Edit';
 import Color from 'color';
 import styles from './utils/style.module.css';
+import PPGraph from './classes/GraphClass';
 import PPNode from './classes/NodeClass';
 import Socket from './classes/SocketClass';
 import { PropertyArrayContainer } from './PropertyArrayContainer';
@@ -32,6 +34,23 @@ function InspectorHeaderReadOnly(props) {
           alignItems: 'center',
         }}
       >
+        <IconButton
+          title="Unselect nodes"
+          color="secondary"
+          size="small"
+          sx={{
+            color: `${
+              Color(props.randomMainColor).isDark()
+                ? COLOR_WHITE_TEXT
+                : COLOR_DARK
+            }`,
+          }}
+          onClick={() => {
+            PPGraph.currentGraph.selection.deselectAllNodes();
+          }}
+        >
+          <ArrowBackIcon fontSize="inherit" />
+        </IconButton>
         <Typography
           sx={{
             pl: 1,
@@ -64,7 +83,25 @@ function InspectorHeader(props) {
           alignItems: 'center',
         }}
       >
+        <IconButton
+          title="Unselect nodes"
+          color="secondary"
+          size="small"
+          sx={{
+            color: `${
+              Color(props.randomMainColor).isDark()
+                ? COLOR_WHITE_TEXT
+                : COLOR_DARK
+            }`,
+          }}
+          onClick={() => {
+            PPGraph.currentGraph.selection.deselectAllNodes();
+          }}
+        >
+          <ArrowBackIcon fontSize="inherit" />
+        </IconButton>
         <TextField
+          title={props.selectedNodes[0].id}
           hiddenLabel
           inputRef={textInput}
           disabled={props.selectedNodes.length !== 1}
@@ -108,6 +145,13 @@ function InspectorHeader(props) {
           title="Edit node name"
           color="secondary"
           size="small"
+          sx={{
+            color: `${
+              Color(props.randomMainColor).isDark()
+                ? COLOR_WHITE_TEXT
+                : COLOR_DARK
+            }`,
+          }}
           onClick={() => {
             setTimeout(() => {
               textInput.current.focus();

--- a/src/NodeArrayContainer.tsx
+++ b/src/NodeArrayContainer.tsx
@@ -1,0 +1,256 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemSecondaryAction,
+  Stack,
+} from '@mui/material';
+import Color from 'color';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { getLoadNodeExampleURL } from './utils/utils';
+import { ensureVisible, zoomToFitNodes } from './pixi/utils-pixi';
+// import { SerializedNode, SerializedSelection } from './utils/interfaces';
+import PPGraph from './classes/GraphClass';
+import PPNode from './classes/NodeClass';
+// import { CodeEditor } from './components/Editor';
+import InterfaceController, { ListenEvent } from './InterfaceController';
+
+const NodesContent = (props) => {
+  return (
+    <>
+      <h3>Nodes in playground</h3>
+      <List
+        sx={{
+          width: '100%',
+          bgcolor: 'background.paper',
+          position: 'relative',
+          overflow: 'auto',
+          paddingLeft: '0 !important',
+        }}
+        subheader={<li />}
+      >
+        {Object.entries(props.nodes).map((property, index) => {
+          return (
+            <NodeItem
+              key={index}
+              property={property}
+              randomMainColor={props.randomMainColor}
+              index={index}
+              sx={{
+                listStyleType: 'none',
+              }}
+            />
+          );
+        })}
+      </List>
+    </>
+  );
+};
+
+const NodeItem = (props) => {
+  console.log(props);
+  return (
+    <ListItem
+      key={`item-${props.property[1].title}`}
+      sx={{
+        p: 0,
+        '&:hover + .MuiListItemSecondaryAction-root': {
+          visibility: 'visible',
+        },
+        bgcolor: `${Color(props.randomMainColor).darken(0.6)}`,
+        margin: '1px 0',
+      }}
+      title="Add node"
+      onPointerEnter={(event: React.MouseEvent<HTMLLIElement>) => {
+        event.stopPropagation();
+        const nodeToJumpTo = PPGraph.currentGraph.nodes[props.property[0]];
+        if (nodeToJumpTo) {
+          // ensureVisible([nodeToJumpTo]);
+          // zoomToFitNodes([nodeToJumpTo]);
+          nodeToJumpTo.renderOutlineThrottled(100);
+          // setTimeout(() => {
+          //   nodeToJumpTo.renderOutlineThrottled(100);
+          // }, 500);
+        }
+      }}
+    >
+      <ListItemButton
+        sx={{
+          p: 1,
+        }}
+      >
+        <Stack
+          sx={{
+            width: '100%',
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <Box
+              title={props.property[1].description}
+              sx={{
+                flexGrow: 1,
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'inline',
+                }}
+              >
+                {props.property[1].name}
+              </Box>
+            </Box>
+            <Box>
+              {props.property[1].tags?.map((part, index) => (
+                <Box
+                  key={index}
+                  sx={{
+                    fontSize: '12px',
+                    background: 'rgba(255,255,255,0.2)',
+                    cornerRadius: '4px',
+                    marginLeft: '2px',
+                    px: 0.5,
+                    display: 'inline',
+                    '.Mui-focused &': {
+                      display: 'none',
+                    },
+                  }}
+                >
+                  {part}
+                </Box>
+              ))}
+            </Box>
+          </Box>
+          <Box
+            sx={{
+              fontSize: '12px',
+              opacity: '0.75',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            <Box
+              sx={{
+                display: 'inline',
+              }}
+            >
+              {props.property[1].description}
+            </Box>
+          </Box>
+        </Stack>
+      </ListItemButton>
+      {props.property[1].hasExample && (
+        <ListItemSecondaryAction
+          sx={{
+            visibility: 'hidden',
+            '&&:hover': {
+              visibility: 'visible',
+            },
+            '.MuiListItem-root:has(+ &:hover)': {
+              background: 'rgba(255, 255, 255, 0.08)',
+            },
+            bgcolor: `${Color(props.randomMainColor).darken(0.6)}`,
+            right: '8px',
+          }}
+        >
+          <IconButton
+            size="small"
+            title="Open node example"
+            className="menuItemButton"
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+              event.stopPropagation();
+              window.open(
+                getLoadNodeExampleURL(props.property[1].title),
+                '_blank',
+              );
+            }}
+            sx={{
+              borderRadius: 0,
+            }}
+          >
+            <Box
+              sx={{
+                color: 'text.secondary',
+                fontSize: '10px',
+                px: 0.5,
+              }}
+            >
+              Open example
+            </Box>
+            <OpenInNewIcon sx={{ fontSize: '16px' }} />
+          </IconButton>
+        </ListItemSecondaryAction>
+      )}
+    </ListItem>
+  );
+};
+
+type NodeArrayContainerProps = {
+  selectedNodes: PPNode[];
+  randomMainColor: string;
+  filter: string;
+  setFilter: React.Dispatch<React.SetStateAction<string>>;
+};
+
+export const NodeArrayContainer: React.FunctionComponent<
+  NodeArrayContainerProps
+> = (props) => {
+  const [dragging, setIsDragging] = useState(false);
+  const singleNode = props.selectedNodes.length ? props.selectedNodes[0] : null;
+  const [selectedNode, setSelectedNode] = useState(singleNode);
+  const [nodesInGraph, setNodesInGraph] = useState({});
+
+  useEffect(() => {
+    const id = InterfaceController.addListener(
+      ListenEvent.SelectionDragging,
+      setIsDragging,
+    );
+    return () => {
+      InterfaceController.removeListener(id);
+    };
+  }, []);
+
+  useEffect(() => {
+    const newSelectedNode =
+      props.selectedNodes.length > 0 ? props.selectedNodes?.[0] : null;
+    setSelectedNode(newSelectedNode);
+  }, [props.selectedNodes]);
+
+  useEffect(() => {
+    const nodes = PPGraph.currentGraph?.nodes;
+    if (nodes) {
+      setNodesInGraph(nodes);
+    }
+  }, [
+    PPGraph.currentGraph?.nodes,
+    PPGraph.currentGraph?.nodes !== undefined &&
+      Object.keys(PPGraph.currentGraph?.nodes).length,
+  ]);
+
+  return (
+    !dragging && (
+      <Box sx={{ width: '100%', m: 1 }}>
+        <Stack
+          spacing={1}
+          sx={{
+            mt: 1,
+            overflow: 'auto',
+            height: 'calc(100vh - 120px)',
+          }}
+        >
+          <NodesContent
+            nodes={nodesInGraph}
+            randomMainColor={props.randomMainColor}
+          />
+        </Stack>
+      </Box>
+    )
+  );
+};

--- a/src/NodeArrayContainer.tsx
+++ b/src/NodeArrayContainer.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
   Box,
-  Button,
-  ButtonGroup,
   IconButton,
   List,
   ListItem,
@@ -19,7 +17,7 @@ import LockIcon from '@mui/icons-material/Lock';
 import Color from 'color';
 import { getConfigData, writeTextToClipboard } from './utils/utils';
 import { ensureVisible, zoomToFitNodes } from './pixi/utils-pixi';
-import { errorColor } from './utils/constants';
+import { ERROR_COLOR } from './utils/constants';
 import { TRgba } from './utils/interfaces';
 import { CodeEditor } from './components/Editor';
 // import { SerializedNode, SerializedSelection } from './utils/interfaces';
@@ -123,15 +121,15 @@ ${props.property
         event.stopPropagation();
         const nodeToJumpTo = PPGraph.currentGraph.nodes[props.property.id];
         if (nodeToJumpTo) {
-          nodeToJumpTo.renderOutlineThrottled(50);
+          PPGraph.currentGraph.selection.drawSingleFocus(nodeToJumpTo);
         }
       }}
       onClick={(event: React.MouseEvent<HTMLLIElement>) => {
         event.stopPropagation();
         const nodeToJumpTo = PPGraph.currentGraph.nodes[props.property.id];
         if (nodeToJumpTo) {
-          nodeToJumpTo.renderOutlineThrottled(20);
           ensureVisible([nodeToJumpTo]);
+          PPGraph.currentGraph.selection.drawSingleFocus(nodeToJumpTo);
           if (event.detail === 2) {
             zoomToFitNodes([nodeToJumpTo], -0.5);
           } else if (event.detail === 3) {
@@ -176,7 +174,7 @@ ${props.property
                   )}
                   sx={{
                     fontSize: '16px',
-                    background: errorColor.hex(),
+                    background: ERROR_COLOR.hex(),
                     marginRight: '8px',
                     px: 0.5,
                     py: '2px',

--- a/src/NodeArrayContainer.tsx
+++ b/src/NodeArrayContainer.tsx
@@ -24,7 +24,7 @@ import { CodeEditor } from './components/Editor';
 // import { SerializedNode, SerializedSelection } from './utils/interfaces';
 import PPGraph from './classes/GraphClass';
 import PPNode from './classes/NodeClass';
-import InterfaceController, { ListenEvent } from './InterfaceController';
+// import InterfaceController, { ListenEvent } from './InterfaceController';
 
 type FilterContentProps = {
   handleFilter: (
@@ -203,9 +203,9 @@ const NodeItem = (props) => {
                 display: 'inline',
               }}
             >
-              {props.property.name === props.property.type
+              {props.property.name === props.property.getName()
                 ? ''
-                : props.property.type}
+                : props.property.getName()}
               {props.property.type === 'Macro'
                 ? props.property.getInsideNodes().map((item) => item.id)
                 : ''}

--- a/src/NodeArrayContainer.tsx
+++ b/src/NodeArrayContainer.tsx
@@ -129,7 +129,9 @@ ${props.property
         const nodeToJumpTo = PPGraph.currentGraph.nodes[props.property.id];
         if (nodeToJumpTo) {
           ensureVisible([nodeToJumpTo]);
-          PPGraph.currentGraph.selection.drawSingleFocus(nodeToJumpTo);
+          setTimeout(() => {
+            PPGraph.currentGraph.selection.drawSingleFocus(nodeToJumpTo);
+          }, 800);
           if (event.detail === 2) {
             zoomToFitNodes([nodeToJumpTo], -0.5);
           } else if (event.detail === 3) {

--- a/src/PPStorage.tsx
+++ b/src/PPStorage.tsx
@@ -221,14 +221,19 @@ export default class PPStorage {
     return undefined;
   }
 
-  async loadGraphFromData(fileData: SerializedGraph, id: string) {
+  async loadGraphFromData(fileData: SerializedGraph, id: string, name: string) {
     if (checkForUnsavedChanges()) {
       try {
         PPGraph.currentGraph.configure(fileData, id);
 
+        InterfaceController.notifyListeners(ListenEvent.GraphChanged, {
+          id,
+          name,
+        });
+
         InterfaceController.showSnackBar('Playground was loaded', {
           variant: 'default',
-          autoHideDuration: 20000,
+          autoHideDuration: 8000,
           action: (key) => (
             <SaveOrDismiss
               saveClick={() => {
@@ -244,7 +249,7 @@ export default class PPStorage {
       } catch (error) {
         InterfaceController.showSnackBar('Loading playground failed.', {
           variant: 'error',
-          autoHideDuration: 20000,
+          autoHideDuration: 8000,
         });
         return undefined;
       }
@@ -255,13 +260,14 @@ export default class PPStorage {
     try {
       const file = await fetch(loadURL);
       const fileData = await file.json();
-      return await this.loadGraphFromData(fileData, hri.random());
+      const id = hri.random();
+      return await this.loadGraphFromData(fileData, id, id);
     } catch (error) {
       InterfaceController.showSnackBar(
         `Loading playground from link in URL failed: ${loadURL}`,
         {
           variant: 'error',
-          autoHideDuration: 20000,
+          autoHideDuration: 8000,
         },
       );
       return undefined;

--- a/src/PropertyArrayContainer.tsx
+++ b/src/PropertyArrayContainer.tsx
@@ -16,7 +16,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import LockIcon from '@mui/icons-material/Lock';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import {
-  getCircularReplacer,
+  getConfigData,
   getLoadNodeExampleURL,
   writeTextToClipboard,
 } from './utils/utils';
@@ -29,10 +29,6 @@ import { SocketContainer } from './SocketContainer';
 import { CodeEditor } from './components/Editor';
 import InterfaceController, { ListenEvent } from './InterfaceController';
 import useInterval from 'use-interval';
-
-function getConfigData(selectedNode) {
-  return JSON.stringify(selectedNode?.serialize(), getCircularReplacer(), 2);
-}
 
 type FilterContentProps = {
   handleFilter: (

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -26,6 +26,7 @@ import FlowLogic from './FlowLogic';
 import InterfaceController, { ListenEvent } from '../InterfaceController';
 import { v4 as uuid } from 'uuid';
 import { dynamicImport } from '../utils/dynamicImport';
+import { ONCLICK_DOUBLECLICK } from '../utils/constants';
 
 export default class PPGraph {
   static currentGraph: PPGraph;
@@ -160,7 +161,7 @@ export default class PPGraph {
     console.log('onPointerClick');
 
     // check if double clicked
-    if (event.detail === 2) {
+    if (event.detail === ONCLICK_DOUBLECLICK) {
       event.stopPropagation();
       const target = event.target;
       if (target instanceof Viewport) {

--- a/src/classes/NodeClass.tsx
+++ b/src/classes/NodeClass.tsx
@@ -137,7 +137,7 @@ export default class PPNode extends PIXI.Container {
   constructor(type: string, customArgs?: CustomArgs) {
     super();
     this.id = customArgs?.overrideId || hri.random();
-    this.name = type;
+    this.name = this.getName();
     this.type = type;
     this.nodeTriggerSocketArray = [];
     this.inputSocketArray = [];
@@ -553,9 +553,12 @@ export default class PPNode extends PIXI.Container {
 
   // get all sockets that are not part of the base kit for the node
   public getAllNonDefaultSockets(): Socket[] {
-    const defaultIONames = this.getAllInitialSockets().filter(socket => socket.isInput()).map((socket) => socket.name);
-    return this.getAllInputSockets()
-      .filter((socket) => !defaultIONames.includes(socket.name));
+    const defaultIONames = this.getAllInitialSockets()
+      .filter((socket) => socket.isInput())
+      .map((socket) => socket.name);
+    return this.getAllInputSockets().filter(
+      (socket) => !defaultIONames.includes(socket.name),
+    );
   }
 
   public getAllInputSockets(): Socket[] {
@@ -586,10 +589,13 @@ export default class PPNode extends PIXI.Container {
   }
 
   getInputOrTriggerSocketByName(slotName: string): Socket {
-    const found = this.getAllInputSockets().find(el => el.name === slotName);
-    if (found === undefined){
+    const found = this.getAllInputSockets().find((el) => el.name === slotName);
+    if (found === undefined) {
       // create new socket for this ask, maybe this is a bit ugly
-      console.log("creating new socket because someone is trying to get a socket that didnt exist: " + slotName);
+      console.log(
+        'creating new socket because someone is trying to get a socket that didnt exist: ' +
+          slotName,
+      );
       const newSocket = new Socket(SOCKET_TYPE.IN, slotName, new AnyType());
       this.addSocket(newSocket);
       this.resizeAndDraw();
@@ -976,9 +982,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     const executedSuccessOld = this.successfullyExecuted;
     try {
       this.successfullyExecuted = true;
-      if (
-        PPGraph.currentGraph.showExecutionVisualisation
-      ) {
+      if (PPGraph.currentGraph.showExecutionVisualisation) {
         this.renderOutlineThrottled();
       }
       await this.rawExecute();
@@ -1117,64 +1121,68 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
   }
 
   public getSocketForNewConnection(socket: Socket): Socket {
-  const socketArray = socket.isInput()
-    ? this.outputSocketArray
-    : this.inputSocketArray;
-  if (socketArray.length > 0) {
-    const getSocket = (
-      condition,
-      onlyFreeSocket,
-      onlyVisibleSocket = true,
-    ): Socket => {
-      return socketArray.find((socketInArray) => {
+    const socketArray = socket.isInput()
+      ? this.outputSocketArray
+      : this.inputSocketArray;
+    if (socketArray.length > 0) {
+      const getSocket = (
+        condition,
+        onlyFreeSocket,
+        onlyVisibleSocket = true,
+      ): Socket => {
+        return socketArray.find((socketInArray) => {
+          return (
+            (!onlyVisibleSocket || socketInArray.visible) &&
+            condition(socketInArray) &&
+            (!onlyFreeSocket || !socketInArray.hasLink())
+          );
+        });
+      };
+
+      const preferredCondition = (socketInArray): boolean => {
+        const preferredSocketName = socketInArray.isInput()
+          ? this.getPreferredInputSocketName()
+          : this.getPreferredOutputSocketName();
+        return socketInArray.name === preferredSocketName;
+      };
+
+      const exactMatchCondition = (socketInArray): boolean => {
         return (
-          (!onlyVisibleSocket || socketInArray.visible) &&
-          condition(socketInArray) &&
-          (!onlyFreeSocket || !socketInArray.hasLink())
+          socketInArray.dataType.constructor === socket.dataType.constructor
         );
-      });
-    };
+      };
 
-    const preferredCondition = (socketInArray): boolean => {
-      const preferredSocketName = socketInArray.isInput()
-        ? this.getPreferredInputSocketName()
-        : this.getPreferredOutputSocketName();
-      return socketInArray.name === preferredSocketName;
-    };
+      const anyTypeCondition = (socketInArray): boolean => {
+        return socketInArray.dataType.constructor === new AnyType().constructor;
+      };
 
-    const exactMatchCondition = (socketInArray): boolean => {
-      return socketInArray.dataType.constructor === socket.dataType.constructor;
-    };
+      const anyCondition = (): boolean => {
+        return true;
+      };
 
-    const anyTypeCondition = (socketInArray): boolean => {
-      return socketInArray.dataType.constructor === new AnyType().constructor;
-    };
-
-    const anyCondition = (): boolean => {
-      return true;
-    };
-
-    return (
-      getSocket(preferredCondition, true, false) ?? // get preferred with no link
-      getSocket(exactMatchCondition, true) ?? // get exact match with no link
-      getSocket(anyTypeCondition, true) ?? // get anyType with no link
-      getSocket(anyCondition, true) ?? // get any with no link
-      // no match free and visible
-      getSocket(preferredCondition, false, false) ??
-      getSocket(exactMatchCondition, false) ??
-      getSocket(anyTypeCondition, false) ??
-      getSocket(anyCondition, false) ??
-      // no match linked and visible
-      getSocket(exactMatchCondition, false, false) ??
-      getSocket(anyTypeCondition, false, false) ??
-      getSocket(anyCondition, false, false)
-    );
+      return (
+        getSocket(preferredCondition, true, false) ?? // get preferred with no link
+        getSocket(exactMatchCondition, true) ?? // get exact match with no link
+        getSocket(anyTypeCondition, true) ?? // get anyType with no link
+        getSocket(anyCondition, true) ?? // get any with no link
+        // no match free and visible
+        getSocket(preferredCondition, false, false) ??
+        getSocket(exactMatchCondition, false) ??
+        getSocket(anyTypeCondition, false) ??
+        getSocket(anyCondition, false) ??
+        // no match linked and visible
+        getSocket(exactMatchCondition, false, false) ??
+        getSocket(anyTypeCondition, false, false) ??
+        getSocket(anyCondition, false, false)
+      );
+    }
+    // node does not have an in/output socket
+    return undefined;
   }
-  // node does not have an in/output socket
-  return undefined;
-};
 
-  protected async mouseReleasedOverWithSourceSocketSelected(source: Socket) : Promise<void>{
+  protected async mouseReleasedOverWithSourceSocketSelected(
+    source: Socket,
+  ): Promise<void> {
     await connectNodeToSocket(source, this);
   }
 
@@ -1206,9 +1214,13 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     );
     this.listenId.forEach((id) => InterfaceController.removeListener(id));
 
-    await Promise.all(this.getAllSockets().map(async (socket) => {
-      await Promise.all(socket.links.map(async (link) => await link.delete()))
-    }));
+    await Promise.all(
+      this.getAllSockets().map(async (socket) => {
+        await Promise.all(
+          socket.links.map(async (link) => await link.delete()),
+        );
+      }),
+    );
 
     this.onNodeRemoved();
   }
@@ -1290,7 +1302,6 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
   protected getUpdateBehaviour(): UpdateBehaviourClass {
     return new UpdateBehaviourClass(true, false, 1000, this);
   }
-
 
   public allowResize(): boolean {
     return true;
@@ -1380,7 +1391,6 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
   public getAddOutputDescription(): string {
     return 'Add Output';
   }
-
 
   public getShrinkOnSocketRemove(): boolean {
     return true;

--- a/src/classes/NodeClass.tsx
+++ b/src/classes/NodeClass.tsx
@@ -24,6 +24,7 @@ import {
   NODE_SOURCE,
   NODE_TEXTSTYLE,
   NODE_WIDTH,
+  ONCLICK_DOUBLECLICK,
   SOCKET_HEIGHT,
   SOCKET_TYPE,
 } from '../utils/constants';
@@ -1252,7 +1253,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
       ),
     );
     // check if double clicked
-    if (event.detail === 2) {
+    if (event.detail === ONCLICK_DOUBLECLICK) {
       this.doubleClicked = true;
       this.listenId.push(
         InterfaceController.addListener(

--- a/src/classes/NodeClass.tsx
+++ b/src/classes/NodeClass.tsx
@@ -951,13 +951,17 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
             1.0 - i * (1.0 / iterations),
           );
         }
-
-        activeExecution.drawRoundedRect(
+        activeExecution.lineStyle(
+          4,
+          new PIXI.Color('#FF0000').toNumber(),
+          1,
+          1,
+        );
+        activeExecution.drawRect(
           NODE_MARGIN,
           0,
           this.nodeWidth,
           this.nodeHeight,
-          this.getRoundedCorners() ? NODE_CORNERRADIUS : 0,
         );
         activeExecution.endFill();
         if (i == iterations) {

--- a/src/classes/NodeClass.tsx
+++ b/src/classes/NodeClass.tsx
@@ -957,17 +957,13 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
             1.0 - i * (1.0 / iterations),
           );
         }
-        activeExecution.lineStyle(
-          4,
-          new PIXI.Color('#FF0000').toNumber(),
-          1,
-          1,
-        );
-        activeExecution.drawRect(
+
+        activeExecution.drawRoundedRect(
           NODE_MARGIN,
           0,
           this.nodeWidth,
           this.nodeHeight,
+          this.getRoundedCorners() ? NODE_CORNERRADIUS : 0,
         );
         activeExecution.endFill();
         if (i == iterations) {

--- a/src/classes/SelectionClass.tsx
+++ b/src/classes/SelectionClass.tsx
@@ -487,8 +487,8 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
     this.singleSelectionsGraphics.clear();
     this.singleSelectionsGraphics.x = 0;
     this.singleSelectionsGraphics.y = 0;
-    this.singleSelectionsGraphics.lineStyle(2, SELECTION_COLOR_HEX, 0.8, 1);
-    this.singleSelectionsGraphics.beginFill(SELECTION_COLOR_HEX, 0.3);
+    this.singleSelectionsGraphics.lineStyle(2, ERROR_COLOR.hexNumber(), 0.8, 1);
+    this.singleSelectionsGraphics.beginFill(ERROR_COLOR.hexNumber(), 0.15);
 
     // draw single selections
     const nodeBounds = node._BackgroundGraphicsRef.getBounds();

--- a/src/classes/SelectionClass.tsx
+++ b/src/classes/SelectionClass.tsx
@@ -492,7 +492,6 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
 
     // draw single selections
     const nodeBounds = node._BackgroundGraphicsRef.getBounds();
-    console.log(nodeBounds);
     this.singleSelectionsGraphics.drawRect(
       nodeBounds.x - 4,
       nodeBounds.y - 4,

--- a/src/classes/SelectionClass.tsx
+++ b/src/classes/SelectionClass.tsx
@@ -9,6 +9,7 @@ import PPNode from './NodeClass';
 import { Tooltipable } from '../components/Tooltip';
 import {
   ALIGNOPTIONS,
+  ERROR_COLOR,
   NODE_MARGIN,
   SCALEHANDLE_SIZE,
   SELECTION_COLOR_HEX,
@@ -84,16 +85,16 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
     this.addEventListener('pointerdown', this.onPointerDown.bind(this));
     this.addEventListener(
       'pointerupoutside',
-      this.onPointerUpAndUpOutside.bind(this)
+      this.onPointerUpAndUpOutside.bind(this),
     );
     this.addEventListener('pointerup', this.onPointerUpAndUpOutside.bind(this));
     this.addEventListener('pointerover', this.onPointerOver.bind(this));
     this.addEventListener('rightclick', (event) =>
-      InterfaceController.onRightClick(event, event.target)
+      InterfaceController.onRightClick(event, event.target),
     );
     this.viewport.addEventListener(
       'moved',
-      (this as any).onViewportMoved.bind(this)
+      (this as any).onViewportMoved.bind(this),
     );
 
     this.onMoveHandler = this.onMove.bind(this);
@@ -110,13 +111,13 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
   onScaling = (pointerPosition: PIXI.Point, shiftKeyPressed: boolean): void => {
     const worldPosition = this.viewport.toWorld(
       pointerPosition.x,
-      pointerPosition.y
+      pointerPosition.y,
     );
 
     this.selectedNodes[0].onBeingScaled(
       Math.abs(worldPosition.x - this.selectedNodes[0].x),
       Math.abs(worldPosition.y - this.selectedNodes[0].y),
-      shiftKeyPressed
+      shiftKeyPressed,
     );
     this.drawRectanglesFromSelection();
   };
@@ -132,7 +133,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
     InterfaceController.notifyListeners(ListenEvent.SelectionDragging, true);
     this.interactionData = event;
     this.sourcePoint = this.interactionData.getLocalPosition(
-      this.selectedNodes[0]
+      this.selectedNodes[0],
     );
 
     this.nodePosBeforeMovement = getCurrentCursorPosition();
@@ -140,7 +141,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
     // subscribe to pointermove
     this.listenID = InterfaceController.addListener(
       ListenEvent.GlobalPointerMove,
-      this.onMoveHandler
+      this.onMoveHandler,
     );
   }
 
@@ -190,15 +191,15 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
           targetPoint.x,
           targetPoint.y,
           1,
-          1
+          1,
         );
         const newlySelectedNodes = getObjectsInsideBounds(
           Object.values(PPGraph.currentGraph.nodes),
-          selectionRect
+          selectionRect,
         );
         const differenceSelection = getDifferenceSelection(
           this.selectedNodes,
-          newlySelectedNodes
+          newlySelectedNodes,
         );
 
         this.selectNodes(differenceSelection, false, true);
@@ -211,7 +212,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
             {
               x: bounds.x + 24,
               y: bounds.y + 24,
-            }
+            },
           );
           this.selectNodes(duplicatedNodes, false, true);
         }
@@ -258,11 +259,11 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
       // previousSelectedNodes (is empty if not addToOrToggleSelection)
       const newlySelectedNodes = getObjectsInsideBounds(
         Object.values(PPGraph.currentGraph.nodes),
-        selectionRect
+        selectionRect,
       );
       const differenceSelection = getDifferenceSelection(
         this.previousSelectedNodes,
-        newlySelectedNodes
+        newlySelectedNodes,
       );
 
       this.selectNodes(differenceSelection);
@@ -270,7 +271,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
       // this.drawSingleSelections();
     } else if (this.isDraggingSelection && this.interactionData) {
       const targetPoint = this.interactionData.getLocalPosition(
-        this.selectedNodes[0]
+        this.selectedNodes[0],
       );
       const deltaX = targetPoint.x - this.sourcePoint.x;
       const deltaY = targetPoint.y - this.sourcePoint.y;
@@ -315,7 +316,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
       node: PPNode,
       alignAndDistribute: TAlignOptions,
       interval: number,
-      index: number
+      index: number,
     ) {
       let x;
       let y;
@@ -410,7 +411,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
 
   drawSelectionStart(
     event: PIXI.FederatedPointerEvent,
-    addToOrToggleSelection: boolean
+    addToOrToggleSelection: boolean,
   ): void {
     // store selectedNodes in previousSelectedNodes
     // if addToOrToggleSelection is true
@@ -429,7 +430,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
     // subscribe to pointermove
     this.listenID = InterfaceController.addListener(
       ListenEvent.GlobalPointerMove,
-      this.onMoveHandler
+      this.onMoveHandler,
     );
   }
 
@@ -450,7 +451,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
     }
     InterfaceController.notifyListeners(
       ListenEvent.SelectionChanged,
-      this.selectedNodes
+      this.selectedNodes,
     );
 
     // only trigger deselect if the mouse was not moved and onMove was not called
@@ -477,9 +478,28 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
         nodeBounds.x,
         nodeBounds.y,
         nodeBounds.width,
-        nodeBounds.height
+        nodeBounds.height,
       );
     });
+  }
+
+  public drawSingleFocus(node: PPNode): void {
+    this.singleSelectionsGraphics.clear();
+    this.singleSelectionsGraphics.x = 0;
+    this.singleSelectionsGraphics.y = 0;
+    this.singleSelectionsGraphics.lineStyle(2, SELECTION_COLOR_HEX, 0.8, 1);
+    this.singleSelectionsGraphics.beginFill(SELECTION_COLOR_HEX, 0.3);
+
+    // draw single selections
+    const nodeBounds = node._BackgroundGraphicsRef.getBounds();
+    console.log(nodeBounds);
+    this.singleSelectionsGraphics.drawRect(
+      nodeBounds.x - 4,
+      nodeBounds.y - 4,
+      nodeBounds.width + 8,
+      nodeBounds.height + 8,
+    );
+    this.singleSelectionsGraphics.endFill();
   }
 
   drawRectanglesFromSelection(fill = true): void {
@@ -499,7 +519,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
       selectionBounds.x,
       selectionBounds.y,
       selectionBounds.width,
-      selectionBounds.height
+      selectionBounds.height,
     );
     this.selectionGraphics.endFill();
 
@@ -521,14 +541,14 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
   screenPoint(): PIXI.Point {
     return new PIXI.Point(
       this.selectionGraphics.getBounds().x + NODE_MARGIN,
-      this.selectionGraphics.getBounds().y
+      this.selectionGraphics.getBounds().y,
     );
   }
 
   selectNodes(
     nodes: PPNode[],
     addToOrToggleSelection = false,
-    notify = false
+    notify = false,
   ): void {
     if (nodes == null) {
       this.deselectAllNodes();
@@ -536,7 +556,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
       if (addToOrToggleSelection) {
         const differenceSelection = getDifferenceSelection(
           this.selectedNodes,
-          nodes
+          nodes,
         );
         this.selectedNodes = differenceSelection;
       } else {
@@ -555,7 +575,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
     if (notify) {
       InterfaceController.notifyListeners(
         ListenEvent.SelectionChanged,
-        this.selectedNodes
+        this.selectedNodes,
       );
     }
   }
@@ -600,7 +620,7 @@ export default class PPSelection extends PIXI.Container implements Tooltipable {
     const absPos = this.selectionGraphics.getBounds();
     return new PIXI.Point(
       Math.max(0, absPos.x - TOOLTIP_WIDTH - TOOLTIP_DISTANCE),
-      absPos.y
+      absPos.y,
     );
   }
 }
@@ -662,7 +682,7 @@ class ScaleHandle extends PIXI.Graphics {
     this._pointerMoveTarget = this;
     this.listenID = InterfaceController.addListener(
       ListenEvent.GlobalPointerMove,
-      this.onPointerMove.bind(this)
+      this.onPointerMove.bind(this),
     );
   }
 

--- a/src/classes/SelectionClass.tsx
+++ b/src/classes/SelectionClass.tsx
@@ -11,6 +11,7 @@ import {
   ALIGNOPTIONS,
   ERROR_COLOR,
   NODE_MARGIN,
+  ONCLICK_DOUBLECLICK,
   SCALEHANDLE_SIZE,
   SELECTION_COLOR_HEX,
   TOOLTIP_DISTANCE,
@@ -714,7 +715,7 @@ class ScaleHandle extends PIXI.Graphics {
 
   protected onPointerClick(event: PIXI.FederatedPointerEvent): void {
     // check if double clicked
-    if (event.detail === 2) {
+    if (event.detail === ONCLICK_DOUBLECLICK) {
       event.stopPropagation();
       this.selection.onScaleReset();
     }

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { Box, Button, Drawer, Paper, Stack } from '@mui/material';
+import { Box, Button, Drawer } from '@mui/material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import TuneIcon from '@mui/icons-material/Tune';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -8,6 +8,7 @@ import Color from 'color';
 import InterfaceController, { ListenEvent } from '../InterfaceController';
 import Socket from '../classes/SocketClass';
 import InspectorContainer from '../InspectorContainer';
+import GraphInspectorContainer from '../GraphInspectorContainer';
 import HelpContainer from '../HelpContainer';
 import { COLOR_DARK, COLOR_WHITE_TEXT } from '../utils/constants';
 import { useIsSmallScreen } from '../utils/utils';
@@ -199,23 +200,12 @@ const ResponsiveDrawer = (props) => {
             setFilter={setFilter}
           />
         ) : (
-          <Paper
-            component={Stack}
-            direction="column"
-            justifyContent="center"
-            sx={{ height: '100%', background: 'unset' }}
-          >
-            <Box
-              sx={{
-                textAlign: 'center',
-                color: Color(props.randomMainColor).isDark()
-                  ? COLOR_WHITE_TEXT
-                  : COLOR_DARK,
-              }}
-            >
-              No node selected
-            </Box>
-          </Paper>
+          <GraphInspectorContainer
+            selectedNodes={props.selectedNodes}
+            randomMainColor={props.randomMainColor}
+            filter={filter}
+            setFilter={setFilter}
+          />
         )}
       </Drawer>
     </>

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -74,6 +74,7 @@ const ResponsiveDrawer = (props) => {
   const [filter, setFilter] = useState(null);
   const [helpFilter, setHelpFilter] = useState('create');
   const [graphFilter, setGraphFilter] = useState('nodes');
+  const [graphFilterText, setGraphFilterText] = useState('');
   const [socketToInspect, setSocketToInspect] = useState<Socket | undefined>(
     undefined,
   );
@@ -206,6 +207,8 @@ const ResponsiveDrawer = (props) => {
             randomMainColor={props.randomMainColor}
             filter={graphFilter}
             setFilter={setGraphFilter}
+            filterText={graphFilterText}
+            setFilterText={setGraphFilterText}
           />
         )}
       </Drawer>

--- a/src/components/ResponsiveDrawer.tsx
+++ b/src/components/ResponsiveDrawer.tsx
@@ -73,6 +73,7 @@ const ResponsiveDrawer = (props) => {
   const [open, setOpen] = useState(true);
   const [filter, setFilter] = useState(null);
   const [helpFilter, setHelpFilter] = useState('create');
+  const [graphFilter, setGraphFilter] = useState('nodes');
   const [socketToInspect, setSocketToInspect] = useState<Socket | undefined>(
     undefined,
   );
@@ -203,8 +204,8 @@ const ResponsiveDrawer = (props) => {
           <GraphInspectorContainer
             selectedNodes={props.selectedNodes}
             randomMainColor={props.randomMainColor}
-            filter={filter}
-            setFilter={setFilter}
+            filter={graphFilter}
+            setFilter={setGraphFilter}
           />
         )}
       </Drawer>

--- a/src/dragAndDrop.ts
+++ b/src/dragAndDrop.ts
@@ -1,4 +1,5 @@
 import * as PIXI from 'pixi.js';
+import { hri } from 'human-readable-ids';
 import InterfaceController from './InterfaceController';
 import PPStorage from './PPStorage';
 import PPGraph from './classes/GraphClass';
@@ -48,6 +49,7 @@ export const dragAndDrop = (acceptedFiles, fileRejections, event) => {
           data = await response.text();
           await PPStorage.getInstance().loadGraphFromData(
             JSON.parse(data),
+            hri.random(),
             preExtension,
           );
           break;

--- a/src/nodes/api/http.tsx
+++ b/src/nodes/api/http.tsx
@@ -2,10 +2,10 @@ import PPNode from '../../classes/NodeClass';
 import Socket from '../../classes/SocketClass';
 import { wrapDownloadLink } from '../../utils/utils';
 import {
-  errorColor,
+  ERROR_COLOR,
   NODE_TYPE_COLOR,
   SOCKET_TYPE,
-  successColor,
+  SUCCESS_COLOR,
 } from '../../utils/constants';
 import { TRgba } from '../../utils/interfaces';
 import { BooleanType } from '../datatypes/booleanType';
@@ -106,7 +106,7 @@ export class HTTPNode extends PPNode {
 
   protected pushStatusCode(statusCode: number): void {
     this.statuses.push({
-      color: statusCode > 400 ? errorColor : successColor,
+      color: statusCode > 400 ? ERROR_COLOR : SUCCESS_COLOR,
       statusText: 'Status: ' + statusCode,
     });
     this.drawStatuses();

--- a/src/nodes/macro/macro.ts
+++ b/src/nodes/macro/macro.ts
@@ -231,7 +231,10 @@ export class Macro extends PPNode {
   }
 
   public onSpecificallySelected(): void {
-    PPGraph.currentGraph.selection.selectNodes(this.getInsideNodes());
+    const macroAndNodes = this.getInsideNodes();
+    // add the macro itself to it
+    macroAndNodes.unshift(this);
+    PPGraph.currentGraph.selection.selectNodes(macroAndNodes);
   }
 
   public getInsideNodes(): PPNode[] {
@@ -241,7 +244,6 @@ export class Macro extends PPNode {
       Object.values(PPGraph.currentGraph.nodes),
       myBounds,
     );
-    nodesInside.unshift(this);
     return nodesInside;
   }
 

--- a/src/nodes/macro/macro.ts
+++ b/src/nodes/macro/macro.ts
@@ -231,6 +231,10 @@ export class Macro extends PPNode {
   }
 
   public onSpecificallySelected(): void {
+    PPGraph.currentGraph.selection.selectNodes(this.getInsideNodes());
+  }
+
+  public getInsideNodes(): PPNode[] {
     // get all nodes that are within the bounds
     const myBounds = this.getBounds();
     const nodesInside: PPNode[] = getObjectsInsideBounds(
@@ -238,7 +242,7 @@ export class Macro extends PPNode {
       myBounds,
     );
     nodesInside.unshift(this);
-    PPGraph.currentGraph.selection.selectNodes(nodesInside);
+    return nodesInside;
   }
 
   public shouldShowResizeRectangleEvenWhenMultipleNodesAreSelected(): boolean {

--- a/src/pixi/utils-pixi.tsx
+++ b/src/pixi/utils-pixi.tsx
@@ -104,7 +104,10 @@ export const getNodesBounds = (nodes: PPNode[]): PIXI.Rectangle => {
   return bounds;
 };
 
-export const zoomToFitNodes = (nodes?: PPNode[]): void => {
+export const zoomToFitNodes = (
+  nodes?: PPNode[],
+  initZoomOutFactor = undefined,
+): void => {
   const currentGraph = PPGraph.currentGraph;
   let boundsToZoomTo: PIXI.Rectangle;
   let zoomOutFactor: number;
@@ -122,7 +125,7 @@ export const zoomToFitNodes = (nodes?: PPNode[]): void => {
     boundsToZoomTo.y + boundsToZoomTo.height / 2,
   );
   currentGraph.viewport.fit(true, boundsToZoomTo.width, boundsToZoomTo.height);
-  currentGraph.viewport.zoomPercent(zoomOutFactor, true); // zoom out a bit more
+  currentGraph.viewport.zoomPercent(initZoomOutFactor || zoomOutFactor, true); // zoom out a bit more
   currentGraph.selection.drawRectanglesFromSelection();
   currentGraph.viewport.emit('moved', {
     viewport: currentGraph.viewport,

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -52,9 +52,10 @@ export const COLOR = [
 ];
 
 export const COLOR_WHITE = '#F5F5F5';
+export const WHITE_HEX = 0xf5f5f5;
 export const COLOR_DARK = '#0C0C0C';
+export const DARK_HEX = 0x0c0c0c;
 export const COLOR_WHITE_TEXT = '#F4FAF9';
-export const WHITE_HEX = 0xffffff;
 export const COLOR_ERROR = '#FF0000';
 
 export const RANDOMMAINCOLOR = COLOR[Math.floor(Math.random() * COLOR.length)];

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -16,6 +16,9 @@ export const GESTUREMODE = {
   AUTO: 'Auto detect',
 } as const;
 
+export const ONCLICK_DOUBLECLICK = 2;
+export const ONCLICK_TRIPPLECLICK = 3;
+
 export const ALIGNOPTIONS = {
   ALIGN_LEFT: 'Align left',
   ALIGN_CENTER_HORIZONTAL: 'Align center horizontal',

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -108,8 +108,8 @@ export const PRESET_COLORS = [
   '#D4FF00',
 ];
 
-export const errorColor = TRgba.fromString('#B71C1C');
-export const successColor = TRgba.fromString('#4BB543');
+export const ERROR_COLOR = TRgba.fromString('#B71C1C');
+export const SUCCESS_COLOR = TRgba.fromString('#4BB543');
 
 export const PLUGANDPLAY_ICON = '../assets/PlugAndPlayIcon-transparent.svg';
 export const DRAWER30M_ICON = '../assets/Icon_Drawer30M.svg';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -513,64 +513,6 @@ export async function connectNodeToSocket(
   await PPGraph.currentGraph.action_Connect(output, input);
 }
 
-export const getMatchingSocket = (socket: PPSocket, node: PPNode): PPSocket => {
-  const socketArray = socket.isInput()
-    ? node.outputSocketArray
-    : node.inputSocketArray;
-  if (socketArray.length > 0) {
-    const getSocket = (
-      condition,
-      onlyFreeSocket,
-      onlyVisibleSocket = true,
-    ): PPSocket => {
-      return socketArray.find((socketInArray) => {
-        return (
-          (!onlyVisibleSocket || socketInArray.visible) &&
-          condition(socketInArray) &&
-          (!onlyFreeSocket || !socketInArray.hasLink())
-        );
-      });
-    };
-
-    const preferredCondition = (socketInArray): boolean => {
-      const preferredSocketName = socketInArray.isInput()
-        ? node.getPreferredInputSocketName()
-        : node.getPreferredOutputSocketName();
-      return socketInArray.name === preferredSocketName;
-    };
-
-    const exactMatchCondition = (socketInArray): boolean => {
-      return socketInArray.dataType.constructor === socket.dataType.constructor;
-    };
-
-    const anyTypeCondition = (socketInArray): boolean => {
-      return socketInArray.dataType.constructor === new AnyType().constructor;
-    };
-
-    const anyCondition = (): boolean => {
-      return true;
-    };
-
-    return (
-      getSocket(preferredCondition, true, false) ?? // get preferred with no link
-      getSocket(exactMatchCondition, true) ?? // get exact match with no link
-      getSocket(anyTypeCondition, true) ?? // get anyType with no link
-      getSocket(anyCondition, true) ?? // get any with no link
-      // no match free and visible
-      getSocket(preferredCondition, false, false) ??
-      getSocket(exactMatchCondition, false) ??
-      getSocket(anyTypeCondition, false) ??
-      getSocket(anyCondition, false) ??
-      // no match linked and visible
-      getSocket(exactMatchCondition, false, false) ??
-      getSocket(anyTypeCondition, false, false) ??
-      getSocket(anyCondition, false, false)
-    );
-  }
-  // node does not have an in/output socket
-  return undefined;
-};
-
 export const indexToAlphaNumName = (num: number) => {
   let alpha = '';
 


### PR DESCRIPTION
* Added a node browser which
  * shows all nodes in a graph
    * nodes with errors and macros are on top
  * hovering over a node in the list shows a focus border around the node in the graph
  * clicking on a node in the list centers the node
  * double clicking on a node in the list centers and zooms in onto the node
  * clicking the select node button on a node in the list, selects the node
  * using the arrow in the top of the drawer, let's you go back to the node browser
  * the INFO tab shows
    * a description we can add in the future
    * the JSON of the graph which can be edited and with the replace button be loaded again
* Changed the default name of a node on creation to NOT be the node type, but the given name (getName())
* Updated the "missing nodes test" example

https://github.com/fakob/plug-and-play/assets/4619772/c8687cd4-7bcc-421a-a86f-94ac6824ce41

