### PR TITLE
Fix remaining link and sonarcloud issue

### DIFF
--- a/src/classes/NodeClass.tsx
+++ b/src/classes/NodeClass.tsx
@@ -553,9 +553,12 @@ export default class PPNode extends PIXI.Container {
 
   // get all sockets that are not part of the base kit for the node
   public getAllNonDefaultSockets(): Socket[] {
-    const defaultIONames = this.getAllInitialSockets().filter(socket => socket.isInput()).map((socket) => socket.name);
-    return this.getAllInputSockets()
-      .filter((socket) => !defaultIONames.includes(socket.name));
+    const defaultIONames = this.getAllInitialSockets()
+      .filter((socket) => socket.isInput())
+      .map((socket) => socket.name);
+    return this.getAllInputSockets().filter(
+      (socket) => !defaultIONames.includes(socket.name),
+    );
   }
 
   public getAllInputSockets(): Socket[] {
@@ -586,10 +589,13 @@ export default class PPNode extends PIXI.Container {
   }
 
   getInputOrTriggerSocketByName(slotName: string): Socket {
-    const found = this.getAllInputSockets().find(el => el.name === slotName);
-    if (found === undefined){
+    const found = this.getAllInputSockets().find((el) => el.name === slotName);
+    if (found === undefined) {
       // create new socket for this ask, maybe this is a bit ugly
-      console.log("creating new socket because someone is trying to get a socket that didnt exist: " + slotName);
+      console.log(
+        'creating new socket because someone is trying to get a socket that didnt exist: ' +
+          slotName,
+      );
       const newSocket = new Socket(SOCKET_TYPE.IN, slotName, new AnyType());
       this.addSocket(newSocket);
       this.resizeAndDraw();
@@ -972,9 +978,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     const executedSuccessOld = this.successfullyExecuted;
     try {
       this.successfullyExecuted = true;
-      if (
-        PPGraph.currentGraph.showExecutionVisualisation
-      ) {
+      if (PPGraph.currentGraph.showExecutionVisualisation) {
         this.renderOutlineThrottled();
       }
       await this.rawExecute();
@@ -1113,64 +1117,68 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
   }
 
   public getSocketForNewConnection(socket: Socket): Socket {
-  const socketArray = socket.isInput()
-    ? this.outputSocketArray
-    : this.inputSocketArray;
-  if (socketArray.length > 0) {
-    const getSocket = (
-      condition,
-      onlyFreeSocket,
-      onlyVisibleSocket = true,
-    ): Socket => {
-      return socketArray.find((socketInArray) => {
+    const socketArray = socket.isInput()
+      ? this.outputSocketArray
+      : this.inputSocketArray;
+    if (socketArray.length > 0) {
+      const getSocket = (
+        condition,
+        onlyFreeSocket,
+        onlyVisibleSocket = true,
+      ): Socket => {
+        return socketArray.find((socketInArray) => {
+          return (
+            (!onlyVisibleSocket || socketInArray.visible) &&
+            condition(socketInArray) &&
+            (!onlyFreeSocket || !socketInArray.hasLink())
+          );
+        });
+      };
+
+      const preferredCondition = (socketInArray): boolean => {
+        const preferredSocketName = socketInArray.isInput()
+          ? this.getPreferredInputSocketName()
+          : this.getPreferredOutputSocketName();
+        return socketInArray.name === preferredSocketName;
+      };
+
+      const exactMatchCondition = (socketInArray): boolean => {
         return (
-          (!onlyVisibleSocket || socketInArray.visible) &&
-          condition(socketInArray) &&
-          (!onlyFreeSocket || !socketInArray.hasLink())
+          socketInArray.dataType.constructor === socket.dataType.constructor
         );
-      });
-    };
+      };
 
-    const preferredCondition = (socketInArray): boolean => {
-      const preferredSocketName = socketInArray.isInput()
-        ? this.getPreferredInputSocketName()
-        : this.getPreferredOutputSocketName();
-      return socketInArray.name === preferredSocketName;
-    };
+      const anyTypeCondition = (socketInArray): boolean => {
+        return socketInArray.dataType.constructor === new AnyType().constructor;
+      };
 
-    const exactMatchCondition = (socketInArray): boolean => {
-      return socketInArray.dataType.constructor === socket.dataType.constructor;
-    };
+      const anyCondition = (): boolean => {
+        return true;
+      };
 
-    const anyTypeCondition = (socketInArray): boolean => {
-      return socketInArray.dataType.constructor === new AnyType().constructor;
-    };
-
-    const anyCondition = (): boolean => {
-      return true;
-    };
-
-    return (
-      getSocket(preferredCondition, true, false) ?? // get preferred with no link
-      getSocket(exactMatchCondition, true) ?? // get exact match with no link
-      getSocket(anyTypeCondition, true) ?? // get anyType with no link
-      getSocket(anyCondition, true) ?? // get any with no link
-      // no match free and visible
-      getSocket(preferredCondition, false, false) ??
-      getSocket(exactMatchCondition, false) ??
-      getSocket(anyTypeCondition, false) ??
-      getSocket(anyCondition, false) ??
-      // no match linked and visible
-      getSocket(exactMatchCondition, false, false) ??
-      getSocket(anyTypeCondition, false, false) ??
-      getSocket(anyCondition, false, false)
-    );
+      return (
+        getSocket(preferredCondition, true, false) ?? // get preferred with no link
+        getSocket(exactMatchCondition, true) ?? // get exact match with no link
+        getSocket(anyTypeCondition, true) ?? // get anyType with no link
+        getSocket(anyCondition, true) ?? // get any with no link
+        // no match free and visible
+        getSocket(preferredCondition, false, false) ??
+        getSocket(exactMatchCondition, false) ??
+        getSocket(anyTypeCondition, false) ??
+        getSocket(anyCondition, false) ??
+        // no match linked and visible
+        getSocket(exactMatchCondition, false, false) ??
+        getSocket(anyTypeCondition, false, false) ??
+        getSocket(anyCondition, false, false)
+      );
+    }
+    // node does not have an in/output socket
+    return undefined;
   }
-  // node does not have an in/output socket
-  return undefined;
-};
 
-  protected async mouseReleasedOverWithSourceSocketSelected(source: Socket) : Promise<void>{
+  protected async mouseReleasedOverWithSourceSocketSelected(
+    source: Socket,
+  ): Promise<void> {
     await connectNodeToSocket(source, this);
   }
 
@@ -1202,9 +1210,10 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
     );
     this.listenId.forEach((id) => InterfaceController.removeListener(id));
 
-    await Promise.all(this.getAllSockets().map((socket) => {
-      socket.links.forEach(async (link) => await link.delete())
-    }));
+    const allLinkDeletionPromises = this.getAllSockets().flatMap((socket) =>
+      socket.links.map((link) => link.delete()),
+    );
+    await Promise.all(allLinkDeletionPromises);
 
     this.onNodeRemoved();
   }
@@ -1286,7 +1295,6 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
   protected getUpdateBehaviour(): UpdateBehaviourClass {
     return new UpdateBehaviourClass(true, false, 1000, this);
   }
-
 
   public allowResize(): boolean {
     return true;
@@ -1376,7 +1384,6 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
   public getAddOutputDescription(): string {
     return 'Add Output';
   }
-
 
   public getShrinkOnSocketRemove(): boolean {
     return true;

--- a/src/classes/SocketClass.tsx
+++ b/src/classes/SocketClass.tsx
@@ -21,7 +21,6 @@ import {
   COLOR_MAIN,
 } from '../utils/constants';
 import { AbstractType } from '../nodes/datatypes/abstractType';
-import { TriggerType } from '../nodes/datatypes/triggerType';
 import { dataToType, serializeType } from '../nodes/datatypes/typehelper';
 import { getCurrentCursorPosition } from '../utils/utils';
 import { TextStyle } from 'pixi.js';
@@ -394,7 +393,7 @@ export default class Socket extends PIXI.Container implements Tooltipable {
     const nodes = this.links.map((link) => link.getTarget().getNode());
     const filteredNodes = nodes.filter(
       (node) =>
-        node && node.updateBehaviour.update && node.id !== this.getNode().id,
+        node && node.updateBehaviour.update && node.id !== this.getNode()?.id,
     );
     return filteredNodes;
   }


### PR DESCRIPTION
Fixes
* an issue where connected links would remain when a node was deleted
* an issue sonarcloud has marked as bug

@TobiasElinder if you think this should be solved differently, please take over :-)
Note: in the NodeClass file only the onRemoved function has been updated (around line 1213). Not sure why it shows so much change.

issue was probably introduced here - https://github.com/fakob/plug-and-play/commit/9487760eb41833dbefbbfc79d78531ed8d866de4#diff-9133f083841163ec1329919d2e9b9c2d1efeaef92ec66207fb6ca417283ccb8bL1143

![image](https://github.com/fakob/plug-and-play/assets/4619772/c21a3187-74a2-447e-b700-67630f537d20)

![image](https://github.com/fakob/plug-and-play/assets/4619772/e0081596-2aa7-4bfd-85ff-85ef59d6b2f5)
