### PR TITLE
Fix event from within text input issue and small cleanup

### DIFF
--- a/src/InterfaceController.ts
+++ b/src/InterfaceController.ts
@@ -4,11 +4,7 @@ import { OptionsObject, SnackbarKey, SnackbarMessage } from 'notistack';
 import * as PIXI from 'pixi.js';
 import Socket from './classes/SocketClass';
 import { v4 as uuid } from 'uuid';
-import {
-  isEventComingFromWithinTextInput,
-  isEventComongFromWithinWidget,
-  isMac,
-} from './utils/utils';
+import { isEventComingFromWithinTextInput, isMac } from './utils/utils';
 import PPGraph from './classes/GraphClass';
 import PPStorage from './PPStorage';
 import { ActionHandler } from './utils/actionHandler';
@@ -116,16 +112,13 @@ export default class InterfaceController {
 
   static keysDown = (e: KeyboardEvent): void => {
     const modKey = isMac() ? e.metaKey : e.ctrlKey;
-    const fromWidget = isEventComongFromWithinWidget(e);
     if (!isEventComingFromWithinTextInput(e)) {
       if (modKey) {
         if (!e.shiftKey) {
           switch (e.key.toLowerCase()) {
             case 'a':
-              if (!fromWidget) {
-                PPGraph.currentGraph.selection.selectAllNodes();
-                e.preventDefault();
-              }
+              PPGraph.currentGraph.selection.selectAllNodes();
+              e.preventDefault();
               break;
             case 'f':
               this.openNodeSearch();

--- a/src/utils/inputParser.ts
+++ b/src/utils/inputParser.ts
@@ -1,7 +1,6 @@
 /* eslint-disable prettier/prettier */
 import PPGraph from '../classes/GraphClass';
-import { isEventComingFromWithinTextInput, isEventComongFromWithinWidget } from './utils';
-
+import { isEventComingFromWithinTextInput } from './utils';
 
 // This class didnt really work out TODO deprecate entirely
 
@@ -23,7 +22,7 @@ abstract class Hotkey {
   potentiallyExecute(
     currPressed: KeyboardEvent,
     allPressed: Set<string>,
-    graph: PPGraph
+    graph: PPGraph,
   ): boolean {
     // see if all keys are pressed and if one of the relevant keys was pressed now
     if (this.areKeysPressed(currPressed.key, allPressed)) {
@@ -39,7 +38,7 @@ abstract class Hotkey {
 class deleteNodeAction extends Hotkey {
   potentiallyExecute(currPressed, allPressed, graph): boolean {
     if (currPressed.key === 'Backspace' || currPressed.key === 'Delete') {
-      if (!isEventComongFromWithinWidget(currPressed)) {
+      if (!isEventComingFromWithinTextInput(currPressed)) {
         graph.action_DeleteSelectedNodes();
       }
       return true;
@@ -61,7 +60,7 @@ export class InputParser {
     // console.log('parsed keykey: ' + JSON.stringify(event.key));
     this.keysPressed.add(event.key);
     activeHotkeys.forEach((hotkey) =>
-      hotkey.potentiallyExecute(event, this.keysPressed, graph)
+      hotkey.potentiallyExecute(event, this.keysPressed, graph),
     );
   }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -359,16 +359,10 @@ export const getNodeDataFromText = (text: string): SerializedSelection => {
   return JSON.parse(text) as SerializedSelection;
 };
 
-export const isEventComongFromWithinWidget = (event: any): boolean => {
+export const isEventComingFromWithinTextInput = (event: any): boolean => {
   return (
     (event.target.id as string).endsWith('Input') ||
     event.target.localName === 'input' ||
-    isEventComingFromWithinTextInput(event)
-  );
-};
-
-export const isEventComingFromWithinTextInput = (event: any): boolean => {
-  return (
     event.target.localName === 'textarea' ||
     event.target?.attributes?.['data-slate-editor'] !== undefined ||
     event.target?.attributes?.['data-slate-node'] !== undefined ||


### PR DESCRIPTION
When using Shift+2 or Shift 1 inside the label, it would detect the zoom commands instead of writing @ or !
I noticed that we had two functions for it
* isEventComingFromWithinTextInput
* isEventComongFromWithinWidget

I have now consolidated them into 1. Not sure what the reason was why we/I had thought that there has to be a difference. Do you know?