### PR TITLE
Add individual urls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -262,7 +262,8 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     );
 
     window.addEventListener('popstate', () => {
-      loadGraph();
+      const urlParams = new URLSearchParams(window.location.search);
+      loadGraph(urlParams);
     });
 
     // create viewport
@@ -397,7 +398,8 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     // load plug and playground settings
     PPStorage.getInstance().applyGestureMode(viewport.current);
 
-    loadGraph();
+    const urlParams = new URLSearchParams(window.location.search);
+    loadGraph(urlParams);
 
     console.log('PPGraph.currentGraph:', PPGraph.currentGraph);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,8 +61,8 @@ import {
   controlOrMetaKey,
   cutOrCopyClipboard,
   isPhone,
+  loadGraph,
   pasteClipboard,
-  removeUrlParameter,
   roundNumber,
 } from './utils/utils';
 import { zoomToFitNodes } from './pixi/utils-pixi';
@@ -261,6 +261,10 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
       },
     );
 
+    window.addEventListener('popstate', () => {
+      loadGraph();
+    });
+
     // create viewport
     viewport.current = new Viewport({
       screenWidth: window.innerWidth,
@@ -393,23 +397,7 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     // load plug and playground settings
     PPStorage.getInstance().applyGestureMode(viewport.current);
 
-    const urlParams = new URLSearchParams(window.location.search);
-    const loadURL = urlParams.get('loadURL');
-    const createEmptyGraph = urlParams.get('new');
-    const fetchFromLocalServer = urlParams.get('fetchLocalGraph');
-    console.log('loadURL: ', loadURL, 'new', createEmptyGraph);
-    if (loadURL) {
-      PPStorage.getInstance().loadGraphFromURL(loadURL);
-      removeUrlParameter('loadURL');
-    } else if (fetchFromLocalServer) {
-      PPStorage.getInstance()
-        .getLocallyProvidedGraph(fetchFromLocalServer)
-        .then((serializedGraph) => {
-          PPGraph.currentGraph.configure(serializedGraph, hri.random());
-        });
-    } else if (!createEmptyGraph) {
-      PPStorage.getInstance().loadGraphFromDB();
-    }
+    loadGraph();
 
     console.log('PPGraph.currentGraph:', PPGraph.currentGraph);
 

--- a/src/PPStorage.tsx
+++ b/src/PPStorage.tsx
@@ -11,6 +11,7 @@ import {
   getSetting,
   removeExtension,
   setGestureModeOnViewport,
+  updateLocalIdInURL,
 } from './utils/utils';
 import * as PIXI from 'pixi.js';
 import PPGraph from './classes/GraphClass';
@@ -320,6 +321,8 @@ export default class PPStorage {
           <b>{loadedGraph.name}</b> was loaded
         </span>,
       );
+
+      updateLocalIdInURL(loadedGraph.id);
     } else {
       this.loadGraphFromURL(getExampleURL('', GET_STARTED_GRAPH));
     }

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -8,6 +8,13 @@ import { TRgba } from '../utils/interfaces';
 
 export const PP_VERSION = 0.1;
 
+export const URL_PARAMETER_NAME = {
+  LOADURL: 'loadURL',
+  LOADLOCAL: 'loadLocal',
+  NEW: 'new',
+  FETCHLOCALGRAPH: 'fetchLocalGraph',
+};
+
 export const GET_STARTED_GRAPH = 'Get started - Welcome to Plug and Playground';
 
 export const GESTUREMODE = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -846,8 +846,7 @@ export const getExtensionFromLocalResourceId = (localResourceId) => {
   return getFileExtension(fileName);
 };
 
-export const loadGraph = () => {
-  const urlParams = new URLSearchParams(window.location.search);
+export const loadGraph = (urlParams: URLSearchParams) => {
   const loadURL = urlParams.get(URL_PARAMETER_NAME.LOADURL);
   const localGraphID = urlParams.get(URL_PARAMETER_NAME.LOADLOCAL);
   const createEmptyGraph = urlParams.get(URL_PARAMETER_NAME.NEW);


### PR DESCRIPTION
Added a URL parameter (`loadLocal`) when a local graph is loaded. This allows you to
* load different graphs in different tabs
* go back and forth between different graphs
If there is no `loadLocal` parameter, we fall back to loading the last saved graph.

https://github.com/fakob/plug-and-play/assets/4619772/8be456b8-588f-474c-b756-0fef065c3b45

