### PR TITLE
Fixing chartjs example crash and loading issue

### DIFF
--- a/assets/examples/Drawing a chart with chartjs.ppgraph
+++ b/assets/examples/Drawing a chart with chartjs.ppgraph
@@ -291,27 +291,27 @@
           "socketType": "in",
           "name": "Code",
           "dataType": "{\"class\":\"CodeType\",\"type\":{}}",
-          "data": "//define your function here, node will adapt to inputs automatically\n(chartjs, data) => {\n  const { Chart, registerables } = chartjs;\n\n  Chart.register(...registerables);\n\n\tconst ctx = document.getElementById('kind-ape-68').contentWindow.document.getElementById('myChart2');\n\nlet chartStatus = Chart.getChart(ctx); // <canvas> id\nif (chartStatus != undefined) {\n  chartStatus.destroy();\n}\n\n  const myChart = new Chart(ctx, {\n    type: 'bar',\n    data: data,\n    options: {\n      scales: {\n        y: {\n          beginAtZero: true\n        }\n      }\n    }\n  });\n}",
+          "data": "//define your function here, node will adapt to inputs automatically\n(chartjs, data) => {\n  const { Chart, registerables } = chartjs;\n\n  Chart.register(...registerables);\n\n\tconst ctx = document.getElementById('kind-ape-68').contentWindow.document.getElementById('myChart2');\n\n  let chartStatus = Chart.getChart(ctx); // <canvas> id\n  if (chartStatus != undefined) {\n    chartStatus.destroy();\n  }\n\n  const myChart = new Chart(ctx, {\n    type: 'bar',\n    data: data,\n    options: {\n      scales: {\n        y: {\n          beginAtZero: true\n        }\n      }\n    }\n  });\n\n  return data;\n}",
           "visible": false
         },
         {
           "socketType": "in",
           "name": "chartjs",
-          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "dataType": "{\"class\":\"FunctionType\",\"type\":{}}",
           "defaultData": {},
           "visible": true
         },
         {
           "socketType": "in",
           "name": "data",
-          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{\"strictParsing\":false}}",
           "defaultData": {},
           "visible": true
         },
         {
           "socketType": "out",
           "name": "OutData",
-          "dataType": "{\"class\":\"NumberType\",\"type\":{\"round\":false,\"minValue\":0,\"maxValue\":100,\"stepSize\":0.01}}",
+          "dataType": "{\"class\":\"JSONType\",\"type\":{\"strictParsing\":false}}",
           "visible": true
         }
       ],
@@ -506,7 +506,7 @@
         {
           "socketType": "out",
           "name": "NpmPackage",
-          "dataType": "{\"class\":\"JSONType\",\"type\":{}}",
+          "dataType": "{\"class\":\"FunctionType\",\"type\":{}}",
           "visible": true
         }
       ],

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -24,7 +24,7 @@ export const CodeEditor: React.FunctionComponent<CodeEditorProps> = (props) => {
 
   const [loadAll, setLoadAll] = useState(shouldLoadAll(props.value));
   const [loadedValue, setLoadedValue] = useState(
-    getLoadedValue(props.value, loadAll),
+    getLoadedValue(convertToString(props.value), loadAll),
   );
   const [editorHeight, setEditorHeight] = useState(48);
 
@@ -64,7 +64,7 @@ export const CodeEditor: React.FunctionComponent<CodeEditorProps> = (props) => {
   useEffect(() => {
     const load = shouldLoadAll(props.value);
     setLoadAll(load);
-    setLoadedValue(getLoadedValue(props.value, load));
+    setLoadedValue(getLoadedValue(convertToString(props.value), load));
   }, [props.value]);
 
   useEffect(() => {

--- a/src/nodes/datatypes/functionType.tsx
+++ b/src/nodes/datatypes/functionType.tsx
@@ -22,4 +22,8 @@ export class FunctionType extends AbstractType {
   recommendedInputNodeWidgets(): string[] {
     return ['CodeEditor', 'Constant'];
   }
+
+  allowedToAutomaticallyAdapt(): boolean {
+    return false;
+  }
 }

--- a/src/nodes/utility/utility.ts
+++ b/src/nodes/utility/utility.ts
@@ -341,4 +341,8 @@ export class LoadNPM extends CustomFunction {
 	return npmPackage;
 }`;
   }
+
+  public socketShouldAutomaticallyAdapt(): boolean {
+    return false;
+  }
 }


### PR DESCRIPTION
* fixes
  * the chartjs example crash
  * the issue that the loaded npm package node output could be detected as JSON and then lose all its class members when passed into the custom function input. For this I have made the functionType to not automatically adapt