### PR TITLE
Add update on load

### DIFF
--- a/src/PropertyArrayContainer.tsx
+++ b/src/PropertyArrayContainer.tsx
@@ -100,9 +100,10 @@ function FilterContainer(props: FilterContentProps) {
 
 type CommonContentProps = {
   hasTriggerSocket: boolean;
+  load: boolean;
+  update: boolean;
   interval: boolean;
   intervalFrequency: number;
-  update: boolean;
   onCheckboxChange: (event) => void;
   onFrequencyChange: (event) => void;
   onUpdateNow: (event) => void;
@@ -123,6 +124,17 @@ function CommonContent(props: CommonContentProps) {
             Update now
           </Button>
         </FormGroup>
+        <FormControlLabel
+          control={
+            <Checkbox
+              name="load"
+              checked={props.load}
+              indeterminate={props.load === null}
+              onChange={props.onCheckboxChange}
+            />
+          }
+          label="Update on load"
+        />
         <FormControlLabel
           control={
             <Checkbox
@@ -475,32 +487,31 @@ export const PropertyArrayContainer: React.FunctionComponent<
   // if its value is not the same throughout the array
   // else it returns the value
   const getUpdateBehaviourStateForArray = () => {
-    const areAllIntervalsTheSame = props.selectedNodes.every(
-      (node) =>
-        node.updateBehaviour.interval ===
-        props.selectedNodes[0].updateBehaviour.interval,
-    );
-    const areAllFrequenciesTheSame = props.selectedNodes.every(
-      (node) =>
-        node.updateBehaviour.intervalFrequency ===
-        props.selectedNodes[0].updateBehaviour.intervalFrequency,
-    );
-    const areAllUpdatesTheSame = props.selectedNodes.every(
-      (node) =>
-        node.updateBehaviour.update ===
-        props.selectedNodes[0].updateBehaviour.update,
-    );
+    const isPropertyUniform = (property) => {
+      return props.selectedNodes.every(
+        (node) =>
+          node.updateBehaviour[property] ===
+          props.selectedNodes[0].updateBehaviour[property],
+      );
+    };
+
+    const areAllLoadsTheSame = isPropertyUniform('load');
+    const areAllUpdatesTheSame = isPropertyUniform('update');
+    const areAllIntervalsTheSame = isPropertyUniform('interval');
+    const areAllFrequenciesTheSame = isPropertyUniform('intervalFrequency');
+
+    const firstNodeUpdateBehaviour = props.selectedNodes[0].updateBehaviour;
     const updateBehaviourObject = {
+      load: areAllLoadsTheSame ? firstNodeUpdateBehaviour.load : null,
+      update: areAllUpdatesTheSame ? firstNodeUpdateBehaviour.update : null,
       interval: areAllIntervalsTheSame
-        ? props.selectedNodes[0].updateBehaviour.interval
+        ? firstNodeUpdateBehaviour.interval
         : null,
       intervalFrequency: areAllFrequenciesTheSame
-        ? props.selectedNodes[0].updateBehaviour.intervalFrequency
-        : null,
-      update: areAllUpdatesTheSame
-        ? props.selectedNodes[0].updateBehaviour.update
+        ? firstNodeUpdateBehaviour.intervalFrequency
         : null,
     };
+
     return updateBehaviourObject;
   };
 
@@ -570,9 +581,10 @@ export const PropertyArrayContainer: React.FunctionComponent<
             props.filter == null) && (
             <CommonContent
               hasTriggerSocket={selectedNode.nodeTriggerSocketArray.length > 0}
+              load={updateBehaviour.load}
+              update={updateBehaviour.update}
               interval={updateBehaviour.interval}
               intervalFrequency={updateBehaviour.intervalFrequency}
-              update={updateBehaviour.update}
               onCheckboxChange={onCheckboxChange}
               onFrequencyChange={onFrequencyChange}
               onUpdateNow={onUpdateNow}

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -1115,7 +1115,10 @@ export default class PPGraph {
       ),
     );
     await FlowLogic.executeOptimizedChainBatch(
-      nodes.filter((node) => node.updateBehaviour.load),
+      nodes.filter((node) => {
+        console.log(node.name);
+        return node.updateBehaviour.load;
+      }),
     );
   }
 

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -1114,6 +1114,9 @@ export default class PPGraph {
         (node) => !node.getHasDependencies() && node.updateBehaviour.update,
       ),
     );
+    await FlowLogic.executeOptimizedChainBatch(
+      nodes.filter((node) => node.updateBehaviour.load),
+    );
   }
 
   getInputSocket(nodeID: string, socketName: string): PPSocket {

--- a/src/classes/GraphClass.ts
+++ b/src/classes/GraphClass.ts
@@ -1116,7 +1116,6 @@ export default class PPGraph {
     );
     await FlowLogic.executeOptimizedChainBatch(
       nodes.filter((node) => {
-        console.log(node.name);
         return node.updateBehaviour.load;
       }),
     );

--- a/src/classes/HybridNode2.tsx
+++ b/src/classes/HybridNode2.tsx
@@ -8,6 +8,7 @@ import { Button } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import PPGraph from './GraphClass';
 import PPNode from './NodeClass';
+import UpdateBehaviourClass from './UpdateBehaviourClass';
 import InterfaceController, { ListenEvent } from '../InterfaceController';
 import styles from '../utils/style.module.css';
 import { CustomArgs, TNodeSource, TRgba } from '../utils/interfaces';
@@ -51,6 +52,10 @@ export default abstract class HybridNode2 extends PPNode {
     );
     this.addChildAt(this.shadowPlane, 0);
     await super.onNodeAdded(source);
+  }
+
+  protected getUpdateBehaviour(): UpdateBehaviourClass {
+    return new UpdateBehaviourClass(true, true, false, 1000, this);
   }
 
   redraw({ screenX = 0, screenY = 0, scale = 1 }) {

--- a/src/classes/HybridNode2.tsx
+++ b/src/classes/HybridNode2.tsx
@@ -221,10 +221,6 @@ export default abstract class HybridNode2 extends PPNode {
     this.execute();
   }
 
-  public executeOnPlace(): boolean {
-    return true;
-  }
-
   public getShrinkOnSocketRemove(): boolean {
     return false;
   }

--- a/src/classes/NodeClass.tsx
+++ b/src/classes/NodeClass.tsx
@@ -158,13 +158,11 @@ export default class PPNode extends PIXI.Container implements IWarningHandler {
     this._ForegroundRef.name = 'foreground';
 
     this.hasBeenAdded = true;
-    this.getAllSockets().forEach((socket) =>
-    {
+    this.getAllSockets().forEach((socket) => {
       this._BackgroundRef.addChild(socket);
       socket.onNodeAdded();
-    }
-    );
-    if (this.executeOnPlace() || this.updateBehaviour.update) {
+    });
+    if (this.executeOnPlace()) {
       await this.executeOptimizedChain();
     }
     this.eventMode = 'dynamic';
@@ -406,6 +404,7 @@ export default class PPNode extends PIXI.Container implements IWarningHandler {
       height: this.nodeHeight,
       socketArray: this.getAllSockets().map((socket) => socket.serialize()),
       updateBehaviour: {
+        load: this.updateBehaviour.load,
         update: this.updateBehaviour.update,
         interval: this.updateBehaviour.interval,
         intervalFrequency: this.updateBehaviour.intervalFrequency,
@@ -423,6 +422,7 @@ export default class PPNode extends PIXI.Container implements IWarningHandler {
     this.nodeHeight = nodeConfig.height || this.getMinNodeHeight();
     this.setNodeName(nodeConfig.name);
     this.updateBehaviour = new UpdateBehaviourClass(
+      nodeConfig.updateBehaviour.load ?? false,
       nodeConfig.updateBehaviour.update,
       nodeConfig.updateBehaviour.interval,
       nodeConfig.updateBehaviour.intervalFrequency,
@@ -1350,7 +1350,7 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(true, false, 1000, this);
+    return new UpdateBehaviourClass(false, true, false, 1000, this);
   }
 
   public allowResize(): boolean {

--- a/src/classes/NodeClass.tsx
+++ b/src/classes/NodeClass.tsx
@@ -162,11 +162,16 @@ export default class PPNode extends PIXI.Container implements IWarningHandler {
       this._BackgroundRef.addChild(socket);
       socket.onNodeAdded();
     });
+
     this.eventMode = 'dynamic';
     this._doubleClicked = false;
 
     this._addListeners();
     this.resizeAndDraw();
+
+    if (this.updateBehaviour.load) {
+      await this.executeOptimizedChain();
+    }
   }
 
   public getMinNodeWidth(): number {

--- a/src/classes/NodeClass.tsx
+++ b/src/classes/NodeClass.tsx
@@ -162,9 +162,6 @@ export default class PPNode extends PIXI.Container implements IWarningHandler {
       this._BackgroundRef.addChild(socket);
       socket.onNodeAdded();
     });
-    if (this.executeOnPlace()) {
-      await this.executeOptimizedChain();
-    }
     this.eventMode = 'dynamic';
     this._doubleClicked = false;
 
@@ -1367,10 +1364,6 @@ ${Math.round(this._bounds.minX)}, ${Math.round(
 
   protected getDefaultIO(): Socket[] {
     return [];
-  }
-
-  public executeOnPlace(): boolean {
-    return false;
   }
 
   ////////////////////////////// Meant to be overriden for visual/behavioral needs

--- a/src/classes/UpdateBehaviourClass.ts
+++ b/src/classes/UpdateBehaviourClass.ts
@@ -11,6 +11,7 @@ import {
 } from '../utils/constants';
 
 export interface IUpdateBehaviour {
+  load: boolean;
   update: boolean;
   interval: boolean;
   intervalFrequency: number;
@@ -20,6 +21,7 @@ export default class UpdateBehaviourClass extends PIXI.Container {
   _frequencyRef: PIXI.Text;
   _updateRef: PIXI.Sprite;
   _noUpdateRef: PIXI.Sprite;
+  private _load: boolean;
   private _update: boolean;
   private _interval: boolean;
   private _intervalFrequency: number;
@@ -28,6 +30,7 @@ export default class UpdateBehaviourClass extends PIXI.Container {
   node: PPNode;
 
   constructor(
+    inLoad: boolean,
     inUpdate: boolean,
     inInterval: boolean,
     inIntervalFrequency: number,
@@ -35,6 +38,7 @@ export default class UpdateBehaviourClass extends PIXI.Container {
   ) {
     super();
 
+    this._load = inLoad;
     this._update = inUpdate;
     this._interval = inInterval;
     this._intervalFrequency = inIntervalFrequency;
@@ -120,10 +124,12 @@ export default class UpdateBehaviourClass extends PIXI.Container {
   }
 
   setUpdateBehaviour(
+    newLoad: boolean,
     newUpdate: boolean,
     newInterval: boolean,
     newIntervalFrequency: number,
   ): void {
+    this._load = newLoad;
     this._update = newUpdate;
     this._interval = newInterval;
     this._intervalFrequency = newIntervalFrequency;
@@ -132,12 +138,21 @@ export default class UpdateBehaviourClass extends PIXI.Container {
 
   // GETTERS & SETTERS
 
+  get load(): boolean {
+    return this._load;
+  }
+
+  set load(newLoad: boolean) {
+    this._load = newLoad;
+    this.redrawAnythingChanging();
+  }
+
   get update(): boolean {
     return this._update;
   }
 
-  set update(newInterval: boolean) {
-    this._update = newInterval;
+  set update(newUpdate: boolean) {
+    this._update = newUpdate;
     this.redrawAnythingChanging();
   }
 

--- a/src/nodes/allNodes.ts
+++ b/src/nodes/allNodes.ts
@@ -154,6 +154,7 @@ export const getAllNodesInDetail = (): any[] => {
         });
 
         const updateBehaviour = [
+          node.updateBehaviour.load,
           node.updateBehaviour.update,
           node.updateBehaviour.interval,
           node.updateBehaviour.intervalFrequency,

--- a/src/nodes/api/chatgpt.tsx
+++ b/src/nodes/api/chatgpt.tsx
@@ -35,7 +35,7 @@ export class ChatGPTNode extends HTTPNode {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000, this);
+    return new UpdateBehaviourClass(false, false, false, 1000, this);
   }
 
   protected getDefaultIO(): Socket[] {

--- a/src/nodes/api/jira.tsx
+++ b/src/nodes/api/jira.tsx
@@ -88,7 +88,7 @@ export class Jira_GetProjects extends Jira_Get {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000, this);
+    return new UpdateBehaviourClass(false, false, false, 1000, this);
   }
 }
 
@@ -116,6 +116,6 @@ export class Jira_GetIssues extends Jira_Get {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000, this);
+    return new UpdateBehaviourClass(false, false, false, 1000, this);
   }
 }

--- a/src/nodes/api/pixotopeGateway.tsx
+++ b/src/nodes/api/pixotopeGateway.tsx
@@ -85,7 +85,7 @@ export class PixotopeGatewaySet extends PPNode {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000, this);
+    return new UpdateBehaviourClass(false, false, false, 1000, this);
   }
 
   protected getDefaultIO(): Socket[] {

--- a/src/nodes/base.ts
+++ b/src/nodes/base.ts
@@ -342,7 +342,7 @@ export class RandomArray extends PPNode {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 10000, this);
+    return new UpdateBehaviourClass(false, false, false, 10000, this);
   }
 
   protected getDefaultIO(): PPSocket[] {

--- a/src/nodes/data/test.tsx
+++ b/src/nodes/data/test.tsx
@@ -154,7 +154,7 @@ export class TestDataTypes extends PPNode {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(true, true, 1000, this);
+    return new UpdateBehaviourClass(false, true, true, 1000, this);
   }
 
   getColor(): TRgba {

--- a/src/nodes/data/xml.tsx
+++ b/src/nodes/data/xml.tsx
@@ -1,7 +1,8 @@
 import PPSocket from '../../classes/SocketClass';
-import { TNodeSource, TRgba } from '../../utils/interfaces';
+import { TRgba } from '../../utils/interfaces';
 import { NODE_TYPE_COLOR, SOCKET_TYPE } from '../../utils/constants';
 import PPNode from '../../classes/NodeClass';
+import UpdateBehaviourClass from '../../classes/UpdateBehaviourClass';
 import { JSONType } from '../datatypes/jsonType';
 import { CodeType } from '../datatypes/codeType';
 import PPGraph from '../../classes/GraphClass';
@@ -12,11 +13,6 @@ const inputSocketName = 'Input';
 const IMPORT_NAME = 'xml2js';
 
 export class XMLReader extends PPNode {
-  public onNodeAdded = async (source: TNodeSource): Promise<void> => {
-    await super.onNodeAdded(source);
-    await this.executeOptimizedChain();
-  };
-
   public getName(): string {
     return 'XML reader';
   }
@@ -31,6 +27,10 @@ export class XMLReader extends PPNode {
 
   getColor(): TRgba {
     return TRgba.fromString(NODE_TYPE_COLOR.INPUT);
+  }
+
+  protected getUpdateBehaviour(): UpdateBehaviourClass {
+    return new UpdateBehaviourClass(true, true, false, 1000, this);
   }
 
   protected getDefaultIO(): PPSocket[] {

--- a/src/nodes/data/xml.tsx
+++ b/src/nodes/data/xml.tsx
@@ -12,6 +12,11 @@ const inputSocketName = 'Input';
 const IMPORT_NAME = 'xml2js';
 
 export class XMLReader extends PPNode {
+  public onNodeAdded = async (source: TNodeSource): Promise<void> => {
+    await super.onNodeAdded(source);
+    await this.executeOptimizedChain();
+  };
+
   public getName(): string {
     return 'XML reader';
   }
@@ -26,10 +31,6 @@ export class XMLReader extends PPNode {
 
   getColor(): TRgba {
     return TRgba.fromString(NODE_TYPE_COLOR.INPUT);
-  }
-
-  public executeOnPlace(): boolean {
-    return true;
   }
 
   protected getDefaultIO(): PPSocket[] {

--- a/src/nodes/draw/abstract.tsx
+++ b/src/nodes/draw/abstract.tsx
@@ -1,6 +1,7 @@
 import PPNode from '../../classes/NodeClass';
 import PPGraph from '../../classes/GraphClass';
 import Socket from '../../classes/SocketClass';
+import UpdateBehaviourClass from '../../classes/UpdateBehaviourClass';
 import {
   NODE_TYPE_COLOR,
   PIXI_PIVOT_OPTIONS,
@@ -12,7 +13,7 @@ import * as PIXI from 'pixi.js';
 import { NumberType } from '../datatypes/numberType';
 import { BooleanType } from '../datatypes/booleanType';
 import { ArrayType } from '../datatypes/arrayType';
-import { TNodeSource, TRgba } from '../../utils/interfaces';
+import { TRgba } from '../../utils/interfaces';
 import { DisplayObject } from 'pixi.js';
 import { getCurrentCursorPosition } from '../../utils/utils';
 import { ActionHandler } from '../../utils/actionHandler';
@@ -44,11 +45,6 @@ export abstract class DRAW_Base extends PPNode {
   listenIDMove = '';
   isDragging = false;
 
-  public onNodeAdded = async (source: TNodeSource): Promise<void> => {
-    await super.onNodeAdded(source);
-    await this.executeOptimizedChain();
-  };
-
   public getName(): string {
     return 'Draw';
   }
@@ -68,6 +64,10 @@ export abstract class DRAW_Base extends PPNode {
   onNodeRemoved = (): void => {
     this._ForegroundRef.removeChild(this.deferredGraphics);
   };
+
+  protected getUpdateBehaviour(): UpdateBehaviourClass {
+    return new UpdateBehaviourClass(true, false, false, 1000, this);
+  }
 
   // you probably want to maintain this output in children
   protected getDefaultIO(): Socket[] {
@@ -166,6 +166,7 @@ export abstract class DRAW_Base extends PPNode {
     inputObject: any,
     outputObject: Record<string, unknown>,
   ): Promise<void> {
+    console.trace(this.name);
     const drawingFunction = (container, executions) => {
       if (container) {
         this.drawOnContainer(inputObject, container, executions);

--- a/src/nodes/draw/abstract.tsx
+++ b/src/nodes/draw/abstract.tsx
@@ -12,7 +12,7 @@ import * as PIXI from 'pixi.js';
 import { NumberType } from '../datatypes/numberType';
 import { BooleanType } from '../datatypes/booleanType';
 import { ArrayType } from '../datatypes/arrayType';
-import { TRgba } from '../../utils/interfaces';
+import { TNodeSource, TRgba } from '../../utils/interfaces';
 import { DisplayObject } from 'pixi.js';
 import { getCurrentCursorPosition } from '../../utils/utils';
 import { ActionHandler } from '../../utils/actionHandler';
@@ -43,6 +43,11 @@ export abstract class DRAW_Base extends PPNode {
   listenIDUp = '';
   listenIDMove = '';
   isDragging = false;
+
+  public onNodeAdded = async (source: TNodeSource): Promise<void> => {
+    await super.onNodeAdded(source);
+    await this.executeOptimizedChain();
+  };
 
   public getName(): string {
     return 'Draw';
@@ -321,10 +326,6 @@ export abstract class DRAW_Base extends PPNode {
   }
 
   protected allowMovingDirectly(): boolean {
-    return true;
-  }
-
-  public executeOnPlace(): boolean {
     return true;
   }
 }

--- a/src/nodes/draw/abstract.tsx
+++ b/src/nodes/draw/abstract.tsx
@@ -166,7 +166,6 @@ export abstract class DRAW_Base extends PPNode {
     inputObject: any,
     outputObject: Record<string, unknown>,
   ): Promise<void> {
-    console.trace(this.name);
     const drawingFunction = (container, executions) => {
       if (container) {
         this.drawOnContainer(inputObject, container, executions);

--- a/src/nodes/draw/html.tsx
+++ b/src/nodes/draw/html.tsx
@@ -29,6 +29,7 @@ export class HtmlRenderer extends HybridNode2 {
       this.setInputData(inputSocketNameHtml, this.initialData);
       this.executeOptimizedChain();
     }
+    await this.executeOptimizedChain();
   };
 
   public getName(): string {

--- a/src/nodes/draw/html.tsx
+++ b/src/nodes/draw/html.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import Frame from 'react-frame-component';
 import ErrorFallback from '../../components/ErrorFallback';
 import PPSocket from '../../classes/SocketClass';
+import UpdateBehaviourClass from '../../classes/UpdateBehaviourClass';
 import { CodeType } from '../datatypes/codeType';
 import { TriggerType } from '../datatypes/triggerType';
 import { TNodeSource, TRgba } from '../../utils/interfaces';
@@ -29,7 +30,6 @@ export class HtmlRenderer extends HybridNode2 {
       this.setInputData(inputSocketNameHtml, this.initialData);
       this.executeOptimizedChain();
     }
-    await this.executeOptimizedChain();
   };
 
   public getName(): string {
@@ -73,6 +73,10 @@ export class HtmlRenderer extends HybridNode2 {
 </form>
 </div>
 `;
+  }
+
+  protected getUpdateBehaviour(): UpdateBehaviourClass {
+    return new UpdateBehaviourClass(true, true, false, 1000, this);
   }
 
   protected getDefaultIO(): PPSocket[] {

--- a/src/nodes/graphSegments/simpleBarGraph.json
+++ b/src/nodes/graphSegments/simpleBarGraph.json
@@ -89,6 +89,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": false,
         "interval": false,
         "intervalFrequency": 1000
@@ -238,6 +239,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -334,6 +336,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": false,
         "interval": false,
         "intervalFrequency": 1000
@@ -431,6 +434,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -545,6 +549,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 300
@@ -696,6 +701,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -812,6 +818,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -961,6 +968,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1084,6 +1092,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1127,6 +1136,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1177,6 +1187,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1241,6 +1252,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1364,6 +1376,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1513,6 +1526,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1556,6 +1570,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1592,6 +1607,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1635,6 +1651,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1678,6 +1695,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1714,6 +1732,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1776,6 +1795,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -1925,6 +1945,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -2048,6 +2069,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -2112,6 +2134,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -2162,6 +2185,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -2285,6 +2309,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -2434,6 +2459,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -2494,6 +2520,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -2530,6 +2557,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -2601,6 +2629,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -2672,6 +2701,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000
@@ -2743,6 +2773,7 @@
         }
       ],
       "updateBehaviour": {
+        "load": false,
         "update": true,
         "interval": false,
         "intervalFrequency": 1000

--- a/src/nodes/image/shader.ts
+++ b/src/nodes/image/shader.ts
@@ -135,14 +135,15 @@ export class Shader extends DRAW_Base {
     return TRgba.fromString(NODE_TYPE_COLOR.SHADER);
   }
 
-  public async onNodeAdded(source: TNodeSource): Promise<void> {
+  public onNodeAdded = async (source: TNodeSource): Promise<void> => {
     await super.onNodeAdded(source);
     this.canvas = PPGraph.currentGraph.viewport.getChildByName(
       'backgroundCanvas',
     ) as PIXI.Container;
 
     this.shader = PIXI.Shader.from(this.prevVertex, this.prevFragment);
-  }
+    await this.executeOptimizedChain();
+  };
 
   constructor(name: string, customArgs: CustomArgs) {
     super(name, {

--- a/src/nodes/image/shader.ts
+++ b/src/nodes/image/shader.ts
@@ -227,7 +227,7 @@ export class Shader extends DRAW_Base {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(true, false, 16, this);
+    return new UpdateBehaviourClass(false, true, false, 16, this);
   }
 }
 

--- a/src/nodes/image/shader.ts
+++ b/src/nodes/image/shader.ts
@@ -80,15 +80,19 @@ export class Shader extends DRAW_Base {
   protected getDefaultImages(): Record<string, string> {
     return {};
   }
+
   getCanAddInput(): boolean {
     return true;
   }
+
   public getDescription(): string {
     return 'Draws a shader';
   }
+
   public getName(): string {
     return 'Draw shader';
   }
+
   protected getDefaultIO(): Socket[] {
     return [
       new Socket(
@@ -228,7 +232,7 @@ export class Shader extends DRAW_Base {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, true, false, 16, this);
+    return new UpdateBehaviourClass(true, true, false, 16, this);
   }
 }
 

--- a/src/nodes/macro/macro.ts
+++ b/src/nodes/macro/macro.ts
@@ -62,7 +62,7 @@ export class Macro extends PPNode {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(true, false, 1000, this);
+    return new UpdateBehaviourClass(false, true, false, 1000, this);
   }
 
   async onRemoved(): Promise<void> {

--- a/src/nodes/table/table.tsx
+++ b/src/nodes/table/table.tsx
@@ -932,10 +932,6 @@ export class Table extends HybridNode2 {
     );
   }
 
-  public executeOnPlace(): boolean {
-    return false;
-  }
-
   getJSON(sheet: XLSX.WorkSheet): any {
     const data = this.getXLSXModule().utils.sheet_to_json(sheet);
     return data;

--- a/src/nodes/utility/browser.ts
+++ b/src/nodes/utility/browser.ts
@@ -32,6 +32,6 @@ export class OpenURL extends CustomFunction {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000, this);
+    return new UpdateBehaviourClass(false, false, false, 1000, this);
   }
 }

--- a/src/nodes/utility/utility.ts
+++ b/src/nodes/utility/utility.ts
@@ -175,7 +175,7 @@ export class WriteToClipboard extends PPNode {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000, this);
+    return new UpdateBehaviourClass(false, false, false, 1000, this);
   }
 
   protected getDefaultIO(): Socket[] {
@@ -330,7 +330,7 @@ export class LoadNPM extends CustomFunction {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000, this);
+    return new UpdateBehaviourClass(false, false, false, 1000, this);
   }
 
   protected getDefaultFunction(): string {

--- a/src/nodes/widgets/widgetNodes.tsx
+++ b/src/nodes/widgets/widgetNodes.tsx
@@ -29,7 +29,7 @@ import ColorizeIcon from '@mui/icons-material/Colorize';
 import { SketchPicker } from 'react-color';
 import Socket from '../../classes/SocketClass';
 import { WidgetBase, WidgetHybridBase } from './abstract';
-import { TRgba } from '../../utils/interfaces';
+import { TNodeSource, TRgba } from '../../utils/interfaces';
 import {
   limitRange,
   parseValueAndAttachWarnings,
@@ -226,6 +226,11 @@ const radioDefaultValue = ['A', 'B', 'C'];
 export class WidgetRadio extends WidgetBase {
   radio: RadioGroup | undefined = undefined;
 
+  public onNodeAdded = async (source: TNodeSource): Promise<void> => {
+    await super.onNodeAdded(source);
+    await this.executeOptimizedChain();
+  };
+
   protected getDefaultIO(): Socket[] {
     return [
       new Socket(
@@ -382,10 +387,6 @@ export class WidgetRadio extends WidgetBase {
 
   public allowResize(): boolean {
     return false;
-  }
-
-  public executeOnPlace(): boolean {
-    return true;
   }
 
   public async outputPlugged(): Promise<void> {

--- a/src/nodes/widgets/widgetNodes.tsx
+++ b/src/nodes/widgets/widgetNodes.tsx
@@ -112,7 +112,7 @@ export class WidgetButton extends WidgetBase {
   }
 
   protected getUpdateBehaviour(): UpdateBehaviourClass {
-    return new UpdateBehaviourClass(false, false, 1000, this);
+    return new UpdateBehaviourClass(false, false, false, 1000, this);
   }
 
   protected getDefaultIO(): Socket[] {

--- a/src/nodes/widgets/widgetNodes.tsx
+++ b/src/nodes/widgets/widgetNodes.tsx
@@ -29,7 +29,7 @@ import ColorizeIcon from '@mui/icons-material/Colorize';
 import { SketchPicker } from 'react-color';
 import Socket from '../../classes/SocketClass';
 import { WidgetBase, WidgetHybridBase } from './abstract';
-import { TNodeSource, TRgba } from '../../utils/interfaces';
+import { TRgba } from '../../utils/interfaces';
 import {
   limitRange,
   parseValueAndAttachWarnings,
@@ -226,10 +226,9 @@ const radioDefaultValue = ['A', 'B', 'C'];
 export class WidgetRadio extends WidgetBase {
   radio: RadioGroup | undefined = undefined;
 
-  public onNodeAdded = async (source: TNodeSource): Promise<void> => {
-    await super.onNodeAdded(source);
-    await this.executeOptimizedChain();
-  };
+  protected getUpdateBehaviour(): UpdateBehaviourClass {
+    return new UpdateBehaviourClass(true, false, false, 1000, this);
+  }
 
   protected getDefaultIO(): Socket[] {
     return [


### PR DESCRIPTION
* Added an "Update on load" option which executes the node after everything has been loaded
  * This is helpful for nodes like the HTTP node or Custom functions which should be executed once the graph is loaded, but which you might not want to update always on change

This is different from "Execute on place" which is executed when nothing is connected. It makes sense to keep this hidden away from the user as some nodes rely on it.

<img width="514" alt="Screenshot 2023-12-07 at 22 30 30" src="https://github.com/fakob/plug-and-play/assets/4619772/52a14214-1ce0-4873-b6b2-265df39b651e">
