### PR TITLE
Fix parsing warning on output

### DIFF
--- a/cypress/e2e/pnp/testMultiplyObject.cy.ts
+++ b/cypress/e2e/pnp/testMultiplyObject.cy.ts
@@ -1,0 +1,50 @@
+import { doWithTestController } from './helpers';
+
+describe('testMultiplyObject', () => {
+  it('Check index of multiply object', () => {
+    cy.visit('http://127.0.0.1:8080/?new=true');
+    cy.wait(100);
+    doWithTestController((testController) => {
+      expect(testController.addNode('DRAW_Shape', 'DRAW_Shape')).to.eq(true);
+      expect(
+        testController.addNode('DRAW_Multiplier', 'DRAW_Multiplier'),
+      ).to.eq(true);
+    });
+    cy.wait(100);
+    doWithTestController((testController) => {
+      testController.moveNodeByID('DRAW_Shape', 0, -200);
+      testController.moveNodeByID('DRAW_Multiplier', 0, 100);
+      testController.connectNodesByID(
+        'DRAW_Shape',
+        'DRAW_Multiplier',
+        'Graphics',
+      );
+      testController.setNodeInputValue('DRAW_Shape', 'Offset X', 200);
+      testController.setNodeInputValue(
+        'DRAW_Multiplier',
+        'Clickable objects',
+        true,
+      );
+      testController.setNodeInputValue('DRAW_Multiplier', 'Spacing X', 200);
+      testController.setNodeInputValue('DRAW_Multiplier', 'Offset X', 0);
+      testController.executeNodeByID('DRAW_Shape');
+      expect(
+        testController.getNodeOutputValue(
+          'DRAW_Multiplier',
+          'LastPressedIndex',
+        ),
+      ).to.eq(-1);
+      cy.get('body').click(920, 530); // click on second circle
+    });
+    cy.wait(100);
+    doWithTestController((testController) => {
+      expect(
+        testController.getNodeOutputValue(
+          'DRAW_Multiplier',
+          'LastPressedIndex',
+        ),
+      ).to.eq(1);
+    });
+    cy.wait(100);
+  });
+});

--- a/src/classes/NodeClass.tsx
+++ b/src/classes/NodeClass.tsx
@@ -438,9 +438,11 @@ export default class PPNode extends PIXI.Container implements IWarningHandler {
             item.socketType,
           );
           if (matchingSocket !== undefined) {
-            //matchingSocket.dataType = deSerializeType(item.dataType); // dont override with base serialized type, it kills dynamic enum type, just keep the old one
-            matchingSocket.data = item.data;
-            matchingSocket.defaultData = item.defaultData ?? item.data;
+            // ignore output sockets as no data is stored for them
+            if (item.socketType !== SOCKET_TYPE.OUT) {
+              matchingSocket.data = item.data;
+              matchingSocket.defaultData = item.defaultData ?? item.data;
+            }
             matchingSocket.visible = item.visible;
           } else {
             // add socket if it does not exist yet
@@ -497,7 +499,9 @@ export default class PPNode extends PIXI.Container implements IWarningHandler {
   async executeChildren(): Promise<void> {
     this.drawComment();
     await FlowLogic.executeOptimizedChainBatch(
-      Object.values(this.getDirectDependents()).filter(node => node.updateBehaviour.update),
+      Object.values(this.getDirectDependents()).filter(
+        (node) => node.updateBehaviour.update,
+      ),
     );
   }
 

--- a/src/nodes/draw/abstract.tsx
+++ b/src/nodes/draw/abstract.tsx
@@ -343,7 +343,7 @@ export abstract class DRAW_Interactive_Base extends DRAW_Base {
         SOCKET_TYPE.OUT,
         outputMultiplierIndex,
         new NumberType(true),
-        0,
+        -1,
         () => this.getInputData(objectsInteractive),
       ),
       Socket.getOptionalVisibilitySocket(

--- a/src/nodes/draw/draw.tsx
+++ b/src/nodes/draw/draw.tsx
@@ -463,6 +463,7 @@ export class DRAW_COMBINE_ARRAY extends DRAW_Interactive_Base {
       }
       shallowContainer.x = x * spacingSize.width;
       shallowContainer.y = y * spacingSize.height;
+
       if (inputObject[objectsInteractive]) {
         addShallowContainerEventListeners(
           shallowContainer,
@@ -549,6 +550,7 @@ export class DRAW_Multiplier extends DRAW_Interactive_Base {
       }
       shallowContainer.x = x * inputObject[spacingXName];
       shallowContainer.y = y * inputObject[spacingYName];
+
       addShallowContainerEventListeners(shallowContainer, this, i, executions);
 
       myContainer.addChild(shallowContainer);
@@ -598,6 +600,7 @@ export class DRAW_Multipy_Along extends DRAW_Interactive_Base {
         inputObject[inputGraphicsName](shallowContainer, executions);
       shallowContainer.x = x;
       shallowContainer.y = y;
+
       addShallowContainerEventListeners(shallowContainer, this, i, executions);
 
       myContainer.addChild(shallowContainer);

--- a/src/nodes/draw/draw.tsx
+++ b/src/nodes/draw/draw.tsx
@@ -100,14 +100,17 @@ const addShallowContainerEventListeners = (
 
   shallowContainer.addEventListener('pointerdown', (e) => {
     node.setOutputData(outputMultiplierIndex, index);
-    node.setOutputData(
-      outputMultiplierInjected,
-      node.getInputData(injectedDataName)?.[index],
-    );
+    const injectedData = node.getInputData(injectedDataName);
+    if (injectedData.length > 0) {
+      node.setOutputData(outputMultiplierInjected, injectedData[index]);
+    }
     node.setOutputData(outputMultiplierPointerDown, true);
     // tell all children when something is pressed
     node.executeChildren();
-    console.log('pressed: ' + shallowContainer.x + ' : ' + shallowContainer.y);
+    console.log(
+      `Pressed ${index}: ${shallowContainer.x}, ${shallowContainer.y}`,
+    );
+
     shallowContainer.alpha = alphaPre * 0.6;
   });
 
@@ -460,7 +463,6 @@ export class DRAW_COMBINE_ARRAY extends DRAW_Interactive_Base {
       }
       shallowContainer.x = x * spacingSize.width;
       shallowContainer.y = y * spacingSize.height;
-
       if (inputObject[objectsInteractive]) {
         addShallowContainerEventListeners(
           shallowContainer,
@@ -547,7 +549,6 @@ export class DRAW_Multiplier extends DRAW_Interactive_Base {
       }
       shallowContainer.x = x * inputObject[spacingXName];
       shallowContainer.y = y * inputObject[spacingYName];
-
       addShallowContainerEventListeners(shallowContainer, this, i, executions);
 
       myContainer.addChild(shallowContainer);
@@ -597,7 +598,6 @@ export class DRAW_Multipy_Along extends DRAW_Interactive_Base {
         inputObject[inputGraphicsName](shallowContainer, executions);
       shallowContainer.x = x;
       shallowContainer.y = y;
-
       addShallowContainerEventListeners(shallowContainer, this, i, executions);
 
       myContainer.addChild(shallowContainer);


### PR DESCRIPTION
Fixes this bug - https://trello.com/c/146AVuwW/99-unexpected-warning-about-output-array-on-multiply-draw-node-when-clicking-one-of-the-outputs

* Fixed outputMultiplierInjected error
* Fixed outputs default values getting overridden on load
* Added test