### PR TITLE
Refactor dialogs

### DIFF
--- a/cypress/e2e/pnp/dialogs.cy.ts
+++ b/cypress/e2e/pnp/dialogs.cy.ts
@@ -1,4 +1,5 @@
 import {
+  clickDeleteButtonOfGraph,
   clickEditButtonOfGraph,
   controlOrMetaKey,
   doWithTestController,
@@ -12,6 +13,7 @@ describe('dialogs', () => {
   const newSecondGraphName = 'My 2nd playground';
 
   const getEditDialog = () => cy.get('[data-cy="editDialog"]');
+  const getDeleteDialog = () => cy.get('[data-cy="deleteDialog"]');
 
   before(() => {
     cy.visit('http://127.0.0.1:8080/?new=true');
@@ -126,9 +128,35 @@ describe('dialogs', () => {
   });
 
   // Delete graph dialog
-  it('Opens and closes delete graph dialog via clicking cancel', () => {});
-  it('Opens and closes delete graph dialog via clicking outside', () => {});
-  it('Deletes graph after clicking delete', () => {});
+  it('Opens and closes delete graph dialog via clicking cancel', () => {
+    clickDeleteButtonOfGraph(newGraphName);
+    getDeleteDialog().contains('Delete playground');
+    getDeleteDialog().contains('Cancel').click();
+    getDeleteDialog().should('not.exist');
+  });
+
+  it('Opens and closes delete graph dialog via clicking outside', () => {
+    clickDeleteButtonOfGraph(newGraphName);
+    getDeleteDialog().contains('Delete playground');
+    cy.get('body').click(500, 100); // click outside
+    getDeleteDialog().should('not.exist');
+  });
+
+  it('Deletes other graph after clicking delete', () => {
+    clickDeleteButtonOfGraph(newGraphName);
+    getDeleteDialog().contains('Delete playground');
+    getDeleteDialog().contains('button', 'Delete').click();
+    getDeleteDialog().should('not.exist');
+    cy.get(`[data-cy="hover-${newGraphName}"]`).should('not.exist');
+  });
+
+  it('Deletes current graph after clicking delete', () => {
+    clickDeleteButtonOfGraph(newSecondGraphName);
+    getDeleteDialog().contains('Delete playground');
+    getDeleteDialog().contains('button', 'Delete').click();
+    getDeleteDialog().should('not.exist');
+    cy.get(`[data-cy="hover-${newSecondGraphName}"]`).should('not.exist');
+  });
 
   // Share graph dialog
   it('Opens and closes share graph dialog via clicking cancel', () => {});

--- a/cypress/e2e/pnp/dialogs.cy.ts
+++ b/cypress/e2e/pnp/dialogs.cy.ts
@@ -1,8 +1,12 @@
 import {
+  addFirstTwoNodes,
   clickDeleteButtonOfGraph,
   clickEditButtonOfGraph,
   controlOrMetaKey,
   doWithTestController,
+  getDeleteDialog,
+  getEditDialog,
+  getShareDialog,
   openEditGraph,
 } from './helpers';
 
@@ -12,9 +16,6 @@ describe('dialogs', () => {
   const newGraphName = 'My playground';
   const newSecondGraphName = 'My 2nd playground';
 
-  const getEditDialog = () => cy.get('[data-cy="editDialog"]');
-  const getDeleteDialog = () => cy.get('[data-cy="deleteDialog"]');
-
   before(() => {
     cy.visit('http://127.0.0.1:8080/?new=true');
     doWithTestController((testController) => {
@@ -23,17 +24,7 @@ describe('dialogs', () => {
     });
     cy.wait(100);
     // cy.get('body').type(`${controlOrMetaKey()}{shift}Y`); // enable debug view
-    cy.get('body').type('1'); // close left side menu
-    doWithTestController((testController) => {
-      testController.setShowUnsavedChangesWarning(false);
-      expect(testController.addNode('Constant', 'Constant1')).to.eq(true);
-      expect(testController.addNode('Constant', 'Constant2')).to.eq(true);
-    });
-    cy.wait(100);
-    doWithTestController((testController) => {
-      testController.moveNodeByID('Constant2', 230, 0);
-      testController.connectNodesByID('Constant1', 'Constant2', 'Out', 'In');
-    });
+    addFirstTwoNodes();
     cy.get('body').type('1'); // close left side menu
     cy.get('body').type(`${controlOrMetaKey()}s`); // save graph
     cy.wait(1000)
@@ -49,16 +40,11 @@ describe('dialogs', () => {
       });
   });
 
-  beforeEach(() => {
-    // cy.get('body').click(500, 100); // click outside to close eventual dialogs
-    // cy.reload();
-  });
-
   // Edit graph dialog of current graph
   it('Opens and closes edit graph dialog via clicking cancel', () => {
     openEditGraph();
     getEditDialog().contains('Edit playground details');
-    getEditDialog().contains('Cancel').click();
+    getEditDialog().contains('button', 'Cancel').click();
     getEditDialog().should('not.exist');
   });
 
@@ -82,19 +68,20 @@ describe('dialogs', () => {
       const selectedText = doc.getSelection().toString();
       expect(selectedText).to.equal(graphName);
     });
-    getEditDialog().contains('Cancel').click();
+    getEditDialog().contains('button', 'Cancel').click();
   });
 
   it('Changes graph name after graph name change and clicking save', () => {
     openEditGraph();
-    cy.get('#playground-name-input').type(`${newGraphName}{enter}`);
+    cy.get('#playground-name-input').type(`${newGraphName}`);
+    getEditDialog().contains('button', 'Save').click();
     cy.wait(1000)
       .get('.notistack-SnackbarContainer')
       .contains(`Name changed to ${newGraphName}`)
       .should('exist');
     clickEditButtonOfGraph(newGraphName);
     cy.get('#playground-name-input').should('have.value', newGraphName);
-    getEditDialog().contains('Cancel').click();
+    getEditDialog().contains('button', 'Cancel').click();
   });
 
   // Edit graph dialog of other graph
@@ -122,7 +109,7 @@ describe('dialogs', () => {
             'have.value',
             newSecondGraphName,
           );
-          getEditDialog().contains('Cancel').click();
+          getEditDialog().contains('button', 'Cancel').click();
         }
       });
   });
@@ -131,7 +118,7 @@ describe('dialogs', () => {
   it('Opens and closes delete graph dialog via clicking cancel', () => {
     clickDeleteButtonOfGraph(newGraphName);
     getDeleteDialog().contains('Delete playground');
-    getDeleteDialog().contains('Cancel').click();
+    getDeleteDialog().contains('button', 'Cancel').click();
     getDeleteDialog().should('not.exist');
   });
 
@@ -159,8 +146,16 @@ describe('dialogs', () => {
   });
 
   // Share graph dialog
-  it('Opens and closes share graph dialog via clicking cancel', () => {});
-  it('Opens and closes share graph dialog via clicking outside', () => {});
-  it('Download graph after clicking download', () => {});
-  it('Login to github after clicking login', () => {});
+  it('Opens and closes share graph dialog via clicking cancel', () => {
+    doWithTestController((testController) => {
+      const coordinates = testController.toggleLeftSideDrawer(true);
+    });
+    cy.wait(100);
+    cy.get('[data-cy="shareCurrentButton"]').click();
+    getShareDialog().contains('Share playground');
+    getShareDialog().contains('button', 'Cancel').click();
+    getShareDialog().should('not.exist');
+  });
+  // it('Download graph after clicking download', () => {});
+  // it('Login to github after clicking login', () => {});
 });

--- a/cypress/e2e/pnp/dialogs.cy.ts
+++ b/cypress/e2e/pnp/dialogs.cy.ts
@@ -1,0 +1,138 @@
+import {
+  clickEditButtonOfGraph,
+  controlOrMetaKey,
+  doWithTestController,
+  openEditGraph,
+} from './helpers';
+
+describe('dialogs', () => {
+  let graphName;
+  let secondGraphName;
+  const newGraphName = 'My playground';
+  const newSecondGraphName = 'My 2nd playground';
+
+  const getEditDialog = () => cy.get('[data-cy="editDialog"]');
+
+  before(() => {
+    cy.visit('http://127.0.0.1:8080/?new=true');
+    doWithTestController((testController) => {
+      const coordinates = testController.deleteAllGraphs();
+      // cy.get('body').click(coordinates[0], coordinates[1]);
+    });
+    cy.wait(100);
+    // cy.get('body').type(`${controlOrMetaKey()}{shift}Y`); // enable debug view
+    cy.get('body').type('1'); // close left side menu
+    doWithTestController((testController) => {
+      testController.setShowUnsavedChangesWarning(false);
+      expect(testController.addNode('Constant', 'Constant1')).to.eq(true);
+      expect(testController.addNode('Constant', 'Constant2')).to.eq(true);
+    });
+    cy.wait(100);
+    doWithTestController((testController) => {
+      testController.moveNodeByID('Constant2', 230, 0);
+      testController.connectNodesByID('Constant1', 'Constant2', 'Out', 'In');
+    });
+    cy.get('body').type('1'); // close left side menu
+    cy.get('body').type(`${controlOrMetaKey()}s`); // save graph
+    cy.wait(1000)
+      .get('[id^="notistack-snackbar"]')
+      .contains('was saved')
+      .invoke('text')
+      .then((text) => {
+        const match = text.match(/Playground (.+?) was saved/);
+        if (match) {
+          graphName = match[1];
+          cy.log(graphName);
+        }
+      });
+  });
+
+  beforeEach(() => {
+    // cy.get('body').click(500, 100); // click outside to close eventual dialogs
+    // cy.reload();
+  });
+
+  // Edit graph dialog of current graph
+  it('Opens and closes edit graph dialog via clicking cancel', () => {
+    openEditGraph();
+    getEditDialog().contains('Edit playground details');
+    getEditDialog().contains('Cancel').click();
+    getEditDialog().should('not.exist');
+  });
+
+  it('Opens and closes edit graph dialog via clicking outside', () => {
+    openEditGraph();
+    getEditDialog().contains('Edit playground details');
+    cy.get('body').click(500, 100); // click outside
+    getEditDialog().should('not.exist');
+  });
+
+  it('Opens and closes edit graph dialog via shortcuts', () => {
+    openEditGraph();
+    getEditDialog().contains('Edit playground details');
+    getEditDialog().type('{esc}');
+    getEditDialog().should('not.exist');
+  });
+
+  it('Checks if graph name is selected', () => {
+    openEditGraph();
+    cy.document().then((doc) => {
+      const selectedText = doc.getSelection().toString();
+      expect(selectedText).to.equal(graphName);
+    });
+    getEditDialog().contains('Cancel').click();
+  });
+
+  it('Changes graph name after graph name change and clicking save', () => {
+    openEditGraph();
+    cy.get('#playground-name-input').type(`${newGraphName}{enter}`);
+    cy.wait(1000)
+      .get('.notistack-SnackbarContainer')
+      .contains(`Name changed to ${newGraphName}`)
+      .should('exist');
+    clickEditButtonOfGraph(newGraphName);
+    cy.get('#playground-name-input').should('have.value', newGraphName);
+    getEditDialog().contains('Cancel').click();
+  });
+
+  // Edit graph dialog of other graph
+  it('Changes graph name of other graph after graph name change and clicking save', () => {
+    cy.get('body').type(`${controlOrMetaKey()}{shift}s`); // save new graph
+    cy.wait(1000)
+      .get('[id^="notistack-snackbar"]')
+      .last()
+      .contains('was saved')
+      .invoke('text')
+      .then((text) => {
+        const match = text.match(/Playground (.+?) was saved/);
+        if (match) {
+          secondGraphName = match[1];
+          cy.log(secondGraphName);
+          clickEditButtonOfGraph(secondGraphName);
+          cy.wait(200);
+          cy.get('#playground-name-input').type(`${newSecondGraphName}{enter}`);
+          cy.wait(1000)
+            .get('.notistack-SnackbarContainer')
+            .contains(`Name changed to ${newSecondGraphName}`)
+            .should('exist');
+          clickEditButtonOfGraph(newSecondGraphName);
+          cy.get('#playground-name-input').should(
+            'have.value',
+            newSecondGraphName,
+          );
+          getEditDialog().contains('Cancel').click();
+        }
+      });
+  });
+
+  // Delete graph dialog
+  it('Opens and closes delete graph dialog via clicking cancel', () => {});
+  it('Opens and closes delete graph dialog via clicking outside', () => {});
+  it('Deletes graph after clicking delete', () => {});
+
+  // Share graph dialog
+  it('Opens and closes share graph dialog via clicking cancel', () => {});
+  it('Opens and closes share graph dialog via clicking outside', () => {});
+  it('Download graph after clicking download', () => {});
+  it('Login to github after clicking login', () => {});
+});

--- a/cypress/e2e/pnp/dialogs.cy.ts
+++ b/cypress/e2e/pnp/dialogs.cy.ts
@@ -19,7 +19,7 @@ describe('dialogs', () => {
   before(() => {
     cy.visit('http://127.0.0.1:8080/?new=true');
     doWithTestController((testController) => {
-      const coordinates = testController.deleteAllGraphs();
+      testController.deleteAllGraphs();
       // cy.get('body').click(coordinates[0], coordinates[1]);
     });
     cy.wait(100);
@@ -148,7 +148,7 @@ describe('dialogs', () => {
   // Share graph dialog
   it('Opens and closes share graph dialog via clicking cancel', () => {
     doWithTestController((testController) => {
-      const coordinates = testController.toggleLeftSideDrawer(true);
+      testController.toggleLeftSideDrawer(true);
     });
     cy.wait(100);
     cy.get('[data-cy="shareCurrentButton"]').click();

--- a/cypress/e2e/pnp/helpers.ts
+++ b/cypress/e2e/pnp/helpers.ts
@@ -14,9 +14,15 @@ export function areCoordinatesClose(x1, y1, x2, y2, marginOfError = 1) {
   return distance <= marginOfError;
 }
 
-export function saveGraph(){
-    cy.get('body').type(`${controlOrMetaKey()}s`);
+export function saveGraph() {
+  cy.get('body').type(`${controlOrMetaKey()}s`);
 }
+
+export function openEditGraph() {
+  cy.get('body').type(`${controlOrMetaKey()}e`);
+  cy.wait(200); // wait for text to be selected
+}
+
 export const dragFromAtoB = (startX, startY, endX, endY, wait = false) => {
   cy.get('body')
     .realMouseMove(startX, startY)
@@ -47,7 +53,7 @@ export const beforeEachMouseInteraction = () => {
   cy.visit('http://127.0.0.1:8080/?new=true');
   cy.wait(100);
   // cy.get('body').type(`${controlOrMetaKey()}{shift}Y`); // enable debug view
-  cy.get('body').type('1'); // enable debug view
+  cy.get('body').type('1'); // close left side menu
   doWithTestController((testController) => {
     testController.setShowUnsavedChangesWarning(false);
     expect(testController.addNode('Constant', 'Constant1')).to.eq(true);
@@ -65,4 +71,12 @@ export const afterEachMouseInteraction = () => {
   if (Cypress.$('#custom-mouse-pointer').length) {
     Cypress.$('#custom-mouse-pointer').remove();
   }
+};
+
+export const clickEditButtonOfGraph = (graphName) => {
+  cy.get(`[data-cy="hover-${graphName}"]`)
+    // .realHover()
+    // .wait(1000)
+    .find(`[data-cy="editButton"]`)
+    .click({ force: true });
 };

--- a/cypress/e2e/pnp/helpers.ts
+++ b/cypress/e2e/pnp/helpers.ts
@@ -80,3 +80,11 @@ export const clickEditButtonOfGraph = (graphName) => {
     .find(`[data-cy="editButton"]`)
     .click({ force: true });
 };
+
+export const clickDeleteButtonOfGraph = (graphName) => {
+  cy.get(`[data-cy="hover-${graphName}"]`)
+    // .realHover()
+    // .wait(1000)
+    .find(`[data-cy="deleteButton"]`)
+    .click({ force: true });
+};

--- a/cypress/e2e/pnp/helpers.ts
+++ b/cypress/e2e/pnp/helpers.ts
@@ -14,6 +14,10 @@ export function areCoordinatesClose(x1, y1, x2, y2, marginOfError = 1) {
   return distance <= marginOfError;
 }
 
+export const getDeleteDialog = () => cy.get('[data-cy="deleteDialog"]');
+export const getEditDialog = () => cy.get('[data-cy="editDialog"]');
+export const getShareDialog = () => cy.get('[data-cy="shareDialog"]');
+
 export function saveGraph() {
   cy.get('body').type(`${controlOrMetaKey()}s`);
 }
@@ -31,6 +35,19 @@ export const dragFromAtoB = (startX, startY, endX, endY, wait = false) => {
     .realMouseMove(endX, endY)
     .realMouseUp({ x: endX, y: endY });
   cy.wait(1000);
+};
+
+export const addFirstTwoNodes = () => {
+  doWithTestController((testController) => {
+    testController.setShowUnsavedChangesWarning(false);
+    expect(testController.addNode('Constant', 'Constant1')).to.eq(true);
+    expect(testController.addNode('Constant', 'Constant2')).to.eq(true);
+  });
+  cy.wait(100);
+  doWithTestController((testController) => {
+    testController.moveNodeByID('Constant2', 230, 0);
+    testController.connectNodesByID('Constant1', 'Constant2', 'Out', 'In');
+  });
 };
 
 export const addTwoNodes = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -656,7 +656,8 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
           <EditDialog
             showEdit={showEdit}
             setShowEdit={setShowEdit}
-            graphToBeModified={graphToBeModified}
+            graphId={graphToBeModified?.id}
+            graphName={graphToBeModified?.name}
           />
           {isGraphContextMenuOpen && (
             <GraphContextMenu

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { useDropzone } from 'react-dropzone';
 import * as PIXI from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
-import { Autocomplete, Box, Paper } from '@mui/material';
-import { useTheme } from '@mui/material';
+import { Autocomplete, Box, Paper, useTheme } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import Color from 'color';
 import {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,18 +9,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { useDropzone } from 'react-dropzone';
 import * as PIXI from 'pixi.js';
 import { Viewport } from 'pixi-viewport';
-import {
-  Autocomplete,
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  Paper,
-  TextField,
-} from '@mui/material';
+import { Autocomplete, Box, Paper } from '@mui/material';
 import { useTheme } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import Color from 'color';
@@ -41,7 +30,11 @@ import {
   NodeContextMenu,
   SocketContextMenu,
 } from './components/ContextMenus';
-import { ShareDialog } from './components/Dialogs';
+import {
+  EditDialog,
+  DeleteConfirmationDialog,
+  ShareDialog,
+} from './components/Dialogs';
 import PPGraph from './classes/GraphClass';
 import {
   BASIC_VERTEX_SHADER,
@@ -622,14 +615,6 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
     );
   };
 
-  const submitEditDialog = (): void => {
-    const name = (
-      document.getElementById('playground-name-input') as HTMLInputElement
-    ).value;
-    setShowEdit(false);
-    PPStorage.getInstance().renameGraph(graphToBeModified.id, name);
-  };
-
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback}>
       <div
@@ -663,88 +648,16 @@ Viewport position (scale): ${viewportScreenX}, ${Math.round(
             isLoggedIn={isLoggedIn}
             setIsLoggedIn={setIsLoggedIn}
           />
-          <Dialog
-            open={showDeleteGraph}
-            onClose={() => setShowDeleteGraph(false)}
-            aria-labelledby="alert-dialog-title"
-            aria-describedby="alert-dialog-description"
-            fullWidth
-            maxWidth="sm"
-            sx={{
-              '& .MuiDialog-paper': {
-                bgcolor: 'background.default',
-              },
-            }}
-          >
-            <DialogTitle id="alert-dialog-title">{'Delete Graph?'}</DialogTitle>
-            <DialogContent>
-              <DialogContentText id="alert-dialog-description">
-                Are you sure you want to delete
-                <br />
-                <b>{`${graphToBeModified?.name}`}</b>?
-              </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setShowDeleteGraph(false)} autoFocus>
-                Cancel
-              </Button>
-              <Button
-                onClick={() => {
-                  setShowDeleteGraph(false);
-                  const currentGraphID = PPGraph.currentGraph.id;
-                  const graphToBeModifiedID = graphToBeModified.id;
-                  PPStorage.getInstance().deleteGraph(graphToBeModifiedID);
-                  if (graphToBeModifiedID == currentGraphID) {
-                    PPStorage.getInstance().loadGraphFromDB();
-                  }
-                }}
-              >
-                Delete
-              </Button>
-            </DialogActions>
-          </Dialog>
-          <Dialog
-            open={showEdit}
-            onClose={() => setShowEdit(false)}
-            fullWidth
-            maxWidth="sm"
-            sx={{
-              '& .MuiDialog-paper': {
-                bgcolor: 'background.default',
-              },
-            }}
-          >
-            <DialogTitle>Edit playground details</DialogTitle>
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                submitEditDialog();
-              }}
-            >
-              <DialogContent>
-                <TextField
-                  id="playground-name-input"
-                  autoFocus
-                  margin="dense"
-                  label="Name of playground"
-                  fullWidth
-                  variant="standard"
-                  defaultValue={`${graphToBeModified?.name}`}
-                  placeholder={`${graphToBeModified?.name}`}
-                />
-              </DialogContent>
-              <DialogActions>
-                <Button onClick={() => setShowEdit(false)}>Cancel</Button>
-                <Button
-                  onClick={() => {
-                    submitEditDialog();
-                  }}
-                >
-                  Save
-                </Button>
-              </DialogActions>
-            </form>
-          </Dialog>
+          <DeleteConfirmationDialog
+            showDeleteGraph={showDeleteGraph}
+            setShowDeleteGraph={setShowDeleteGraph}
+            graphToBeModified={graphToBeModified}
+          />
+          <EditDialog
+            showEdit={showEdit}
+            setShowEdit={setShowEdit}
+            graphToBeModified={graphToBeModified}
+          />
           {isGraphContextMenuOpen && (
             <GraphContextMenu
               controlOrMetaKey={controlOrMetaKey()}

--- a/src/LeftsideContent.tsx
+++ b/src/LeftsideContent.tsx
@@ -269,6 +269,7 @@ const GraphsContent = (props) => {
             mr: 1,
           }}
           endIcon={<ShareIcon />}
+          data-cy="shareCurrentButton"
         >
           Share current
         </Button>

--- a/src/LeftsideContent.tsx
+++ b/src/LeftsideContent.tsx
@@ -398,6 +398,7 @@ ${graph.id}`
         />
       </ListItemButton>
       <ListItemSecondaryAction
+        data-cy={`hover-${graph.name}`}
         sx={{
           visibility: 'hidden',
           '&&:hover': {
@@ -420,6 +421,7 @@ ${graph.id}`
                 writeTextToClipboard(url);
               }}
               title="Copy URL"
+              data-cy="copyURLButton"
               className={styles.menuItemButton}
             >
               <LinkIcon />
@@ -427,6 +429,7 @@ ${graph.id}`
             <IconButton
               size="small"
               title="Open in new tab"
+              data-cy="openInNewtabButton"
               className={styles.menuItemButton}
               onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
                 event.stopPropagation();
@@ -447,6 +450,7 @@ ${graph.id}`
                 PPStorage.getInstance().downloadGraph(graph.id);
               }}
               title="Download playground"
+              data-cy="downloadButton"
               className={styles.menuItemButton}
             >
               <DownloadIcon />
@@ -459,6 +463,7 @@ ${graph.id}`
                 InterfaceController.setShowGraphEdit(true);
               }}
               title="Rename playground"
+              data-cy="editButton"
               className={styles.menuItemButton}
             >
               <EditIcon />
@@ -466,6 +471,7 @@ ${graph.id}`
             <IconButton
               size="small"
               title="Delete playground"
+              data-cy="deleteButton"
               className={styles.menuItemButton}
               onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
                 event.stopPropagation();

--- a/src/PPStorage.tsx
+++ b/src/PPStorage.tsx
@@ -211,6 +211,13 @@ export default class PPStorage {
     }
   }
 
+  deleteAllGraphs(): void {
+    this.db.graphs_data.clear();
+    this.db.graphs_meta.clear();
+    InterfaceController.onGraphListChanged();
+    InterfaceController.showSnackBar('Playground was deleted');
+  }
+
   deleteGraph(graphId: string): void {
     this.db.graphs_data.delete(graphId);
     this.db.graphs_meta.delete(graphId);

--- a/src/TestController.ts
+++ b/src/TestController.ts
@@ -7,6 +7,7 @@ import Socket from './classes/SocketClass';
 import { getAllNodeTypes } from './nodes/allNodes';
 import { ActionHandler } from './utils/actionHandler';
 import { STATUS_SEVERITY } from './utils/constants';
+import PPStorage from './PPStorage';
 
 export default class TestController {
   identify(): string {
@@ -137,6 +138,10 @@ export default class TestController {
 
   getGraph(): PPGraph {
     return PPGraph.currentGraph;
+  }
+
+  deleteAllGraphs(): void {
+    PPStorage.getInstance().deleteAllGraphs();
   }
 
   removeNode(nodeID: string): void {

--- a/src/TestController.ts
+++ b/src/TestController.ts
@@ -181,4 +181,8 @@ export default class TestController {
   setShowUnsavedChangesWarning(show: boolean) {
     InterfaceController.showUnsavedChangesWarning = show;
   }
+
+  toggleLeftSideDrawer(open = false) {
+    InterfaceController.toggleLeftSideDrawer(open);
+  }
 }

--- a/src/components/Dialogs.tsx
+++ b/src/components/Dialogs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   Box,
   Button,
@@ -211,6 +211,125 @@ Public gists are visible to everyone.`}
             Cancel
           </Button>
           {props.isLoggedIn && <Button type="submit">Share playground</Button>}
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+};
+
+export const DeleteConfirmationDialog = (props) => {
+  return (
+    <Dialog
+      open={props.showDeleteGraph}
+      onClose={() => props.setShowDeleteGraph(false)}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+      fullWidth
+      maxWidth="sm"
+      sx={{
+        '& .MuiDialog-paper': {
+          bgcolor: 'background.default',
+        },
+      }}
+    >
+      <DialogTitle id="alert-dialog-title">{'Delete Graph?'}</DialogTitle>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          Are you sure you want to delete
+          <br />
+          <b>{`${props.graphToBeModified?.name}`}</b>?
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => props.setShowDeleteGraph(false)} autoFocus>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => {
+            props.setShowDeleteGraph(false);
+            const currentGraphID = PPGraph.currentGraph.id;
+            const graphToBeModifiedID = props.graphToBeModified.id;
+            PPStorage.getInstance().deleteGraph(graphToBeModifiedID);
+            if (graphToBeModifiedID == currentGraphID) {
+              PPStorage.getInstance().loadGraphFromDB();
+            }
+          }}
+        >
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export const EditDialog = (props) => {
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (props.showEdit) {
+      // Slight delay to ensure the TextField is available
+      const timer = setTimeout(() => {
+        if (inputRef.current) {
+          inputRef.current.focus();
+          inputRef.current.select();
+        }
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [props.showEdit]);
+
+  const submitEditDialog = (): void => {
+    const name = (
+      document.getElementById('playground-name-input') as HTMLInputElement
+    ).value;
+    props.setShowEdit(false);
+    PPStorage.getInstance().renameGraph(props.graphToBeModified.id, name);
+  };
+
+  return (
+    <Dialog
+      open={props.showEdit}
+      onClose={() => props.setShowEdit(false)}
+      fullWidth
+      disableRestoreFocus
+      maxWidth="sm"
+      sx={{
+        '& .MuiDialog-paper': {
+          bgcolor: 'background.default',
+        },
+      }}
+    >
+      <DialogTitle>Edit playground details</DialogTitle>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          submitEditDialog();
+        }}
+      >
+        <DialogContent>
+          <TextField
+            id="playground-name-input"
+            autoFocus
+            margin="dense"
+            label="Name of playground"
+            fullWidth
+            variant="standard"
+            defaultValue={`${props.graphToBeModified?.name}`}
+            placeholder={`${props.graphToBeModified?.name}`}
+            InputProps={{
+              inputRef: inputRef,
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => props.setShowEdit(false)}>Cancel</Button>
+          <Button
+            onClick={() => {
+              submitEditDialog();
+            }}
+          >
+            Save
+          </Button>
         </DialogActions>
       </form>
     </Dialog>

--- a/src/components/Dialogs.tsx
+++ b/src/components/Dialogs.tsx
@@ -107,6 +107,7 @@ export const ShareDialog = (props) => {
       aria-describedby="alert-dialog-description"
       fullWidth
       maxWidth="md"
+      data-cy="shareDialog"
     >
       <DialogTitle id="alert-dialog-title">{'Share Playground'}</DialogTitle>
       <form
@@ -226,6 +227,7 @@ export const DeleteConfirmationDialog = (props) => {
       aria-describedby="alert-dialog-description"
       fullWidth
       maxWidth="sm"
+      data-cy="deleteDialog"
       sx={{
         '& .MuiDialog-paper': {
           bgcolor: 'background.default',
@@ -283,7 +285,7 @@ export const EditDialog = (props) => {
       document.getElementById('playground-name-input') as HTMLInputElement
     ).value;
     props.setShowEdit(false);
-    PPStorage.getInstance().renameGraph(props.graphToBeModified.id, name);
+    PPStorage.getInstance().renameGraph(props.graphId, name);
   };
 
   return (
@@ -293,6 +295,7 @@ export const EditDialog = (props) => {
       fullWidth
       disableRestoreFocus
       maxWidth="sm"
+      data-cy="editDialog"
       sx={{
         '& .MuiDialog-paper': {
           bgcolor: 'background.default',
@@ -314,8 +317,8 @@ export const EditDialog = (props) => {
             label="Name of playground"
             fullWidth
             variant="standard"
-            defaultValue={`${props.graphToBeModified?.name}`}
-            placeholder={`${props.graphToBeModified?.name}`}
+            defaultValue={`${props.graphName}`}
+            placeholder={`${props.graphName}`}
             InputProps={{
               inputRef: inputRef,
             }}

--- a/src/components/Dialogs.tsx
+++ b/src/components/Dialogs.tsx
@@ -234,7 +234,7 @@ export const DeleteConfirmationDialog = (props) => {
         },
       }}
     >
-      <DialogTitle id="alert-dialog-title">{'Delete Graph?'}</DialogTitle>
+      <DialogTitle id="alert-dialog-title">{'Delete playground?'}</DialogTitle>
       <DialogContent>
         <DialogContentText id="alert-dialog-description">
           Are you sure you want to delete

--- a/src/components/Dialogs.tsx
+++ b/src/components/Dialogs.tsx
@@ -109,7 +109,7 @@ export const ShareDialog = (props) => {
       maxWidth="md"
       data-cy="shareDialog"
     >
-      <DialogTitle id="alert-dialog-title">{'Share Playground'}</DialogTitle>
+      <DialogTitle id="alert-dialog-title">{'Share playground'}</DialogTitle>
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -174,7 +174,11 @@ Public gists are visible to everyone.`}
                   <Paper sx={{ mx: 1, px: 3, py: 6, textAlign: 'center' }}>
                     Get a shareable link
                     <Box sx={{ m: 3 }}>
-                      <Button variant="contained" href={'/auth-with-github'}>
+                      <Button
+                        variant="contained"
+                        href={'/auth-with-github'}
+                        data-cy="loginWithGithubButton"
+                      >
                         Login with Github
                       </Button>
                     </Box>
@@ -192,6 +196,7 @@ Public gists are visible to everyone.`}
                             PPGraph.currentGraph.id,
                           );
                         }}
+                        data-cy="downloadPlaygroundButton"
                       >
                         Download playground
                       </Button>


### PR DESCRIPTION
* The graph name is now selected when opening the edit dialog to rename it
* Moved the edit and delete dialog out of App.tsx
* Fixed an issue with the graph name not being update when renaming
* Added dialog tests for edit, delete and a one for share. No tests yet
  * for logging into github and sharing a gist
  * for download a file

<img width="656" alt="Screenshot 2024-02-08 at 18 29 44" src="https://github.com/fakob/plug-and-play/assets/4619772/497464ea-4654-45bc-9e78-a9daccaa7b55">
