### PR TITLE
Update enter behaviour for textfield

### DIFF
--- a/cypress/e2e/pnp/dialogs.cy.ts
+++ b/cypress/e2e/pnp/dialogs.cy.ts
@@ -150,7 +150,7 @@ describe('dialogs', () => {
     doWithTestController((testController) => {
       testController.toggleLeftSideDrawer(true);
     });
-    cy.wait(100);
+    cy.wait(1000);
     cy.get('[data-cy="shareCurrentButton"]').click();
     getShareDialog().contains('Share playground');
     getShareDialog().contains('button', 'Cancel').click();

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -352,7 +352,6 @@ export const TextWidget: React.FunctionComponent<StringTypeProps> = (props) => {
   const handleKeyDown = (event) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
-      props.property.getNode().executeOptimizedChain();
     }
   };
 

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -343,6 +343,19 @@ export const TextWidget: React.FunctionComponent<StringTypeProps> = (props) => {
     }
   }, 100);
 
+  const handleChange = (event) => {
+    const value = event.target.value;
+    potentiallyUpdateSocketData(props.property, value);
+    setLoadedData(value);
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      props.property.getNode().executeOptimizedChain();
+    }
+  };
+
   return (
     <FormGroup sx={{ position: 'relative' }}>
       {!loadAll && (
@@ -361,11 +374,8 @@ export const TextWidget: React.FunctionComponent<StringTypeProps> = (props) => {
         variant="filled"
         multiline
         disabled={!loadAll}
-        onChange={(event) => {
-          const value = event.target.value;
-          potentiallyUpdateSocketData(props.property, value);
-          setLoadedData(value);
-        }}
+        onKeyDown={handleKeyDown}
+        onChange={handleChange}
         value={loadedData}
       />
     </FormGroup>


### PR DESCRIPTION
This update only targets the string type
* Clicking Enter will
  * not create a line break anymore
  * trigger executeOptimizedChain
* The value is still updated on change, but the trigger allows a node which is not updated on change, to be triggered via enter. We can remove this, but it made sense to me, at least in Øysteins use case.
* For line break you can do shift+enter