### PR TITLE
Fix code widget not updating in inspector when switching between the same node types

### DIFF
--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -509,6 +509,11 @@ export const DataEditorWidget: React.FunctionComponent<
     }
   }, 100);
 
+  useEffect(() => {
+    const newData = property.getStringifiedData();
+    setDisplayedString(newData);
+  }, [property.getStringifiedData()]);
+
   const onChange = (value: string) => {
     try {
       setDisplayedString(value);


### PR DESCRIPTION
* Fix code widget not updating in inspector when switching between the same node types